### PR TITLE
Added set function in order to change the MML's behaviour on the fly

### DIFF
--- a/lib/grainstore/mml_builder.js
+++ b/lib/grainstore/mml_builder.js
@@ -35,7 +35,7 @@ var supportedDatasourceTypes = {
 //
 // opts must have:
 // `dbname`   - name of database
-// 
+//
 // opts may have:
 // `sql`             - sql to constrain the map by (can be an array)
 // `gcols`           - optional array of geometry column string names (defaulting to type 'geometry')
@@ -54,10 +54,10 @@ var supportedDatasourceTypes = {
 // `dbport`          - Database port
 //
 // @param optional_args
-//     You may pass in a third argument to override grainstore defaults. 
+//     You may pass in a third argument to override grainstore defaults.
 //     `map` specifies the output map projection.
 //     `datasource` specifies postgis details from Mapnik postgis plugin:
-//                  https://github.com/mapnik/mapnik/wiki 
+//                  https://github.com/mapnik/mapnik/wiki
 //     `styles` specifies the default styles
 //     `cachedir` is base directory to put localized external resources into
 //     `carto_env` carto renderer environment options, see
@@ -80,7 +80,7 @@ var supportedDatasourceTypes = {
 //       },
 //       styles: {
 //         point: "default point style",
-//         polygon: "default polygon style",  
+//         polygon: "default polygon style",
 //       }
 //     }
 //
@@ -137,6 +137,18 @@ function MMLBuilder(params, options) {
 }
 
 module.exports = MMLBuilder;
+
+MMLBuilder.prototype.set = function (property, value) {
+    var isOption = this.hasOwnProperty(property) && !_.isFunction(this[property]);
+
+    if (!isOption) {
+        throw new Error('Setting "' + property + '" is not allowed');
+    }
+
+    this[property] = _.extend(this[property], value);
+
+    return this; // allow chaining
+};
 
 MMLBuilder.prototype.toXML = function(callback) {
     var style = this.params.style;

--- a/lib/grainstore/mml_store.js
+++ b/lib/grainstore/mml_store.js
@@ -1,5 +1,6 @@
 var MMLBuilder = require('./mml_builder');
 var fs = require('fs');
+var _ = require('underscore');
 
 // @param optional_args
 //    optional configurations. valid elements:
@@ -7,7 +8,7 @@ var fs = require('fs');
 //              Defaults to '/tmp/millstone'
 //    *: anything else that is accepted by mml_builder "optional_args"
 //       parameter, see mml_builder.js
-//    
+//
 //
 function MMLStore(options) {
   var me = {};
@@ -16,8 +17,8 @@ function MMLStore(options) {
   options.cachedir = options.cachedir || '/tmp/millstone';
 
   // @param callback(err, payload) called on initialization
-  me.mml_builder = function(params) {
-    return new MMLBuilder(params, options);
+  me.mml_builder = function(params, overrideOptions) {
+    return new MMLBuilder(params, _.extend({}, options, overrideOptions));
   };
 
   /// API: Purge cache of localized resources for this store

--- a/test/mml_builder.js
+++ b/test/mml_builder.js
@@ -680,7 +680,6 @@ suite('mml_builder', function() {
         if ( err ) {
             throw err;
         }
-        console.log(data);
         var xmlDoc = libxmljs.parseXmlString(data);
         var node = xmlDoc.find("//Filter");
         assert.equal(node.length, 3);

--- a/test/mml_builder.js
+++ b/test/mml_builder.js
@@ -31,7 +31,7 @@ suite('mml_builder', function() {
   suiteSetup(function(done) {
     // Start a server to test external resources
     server = http.createServer( function(request, response) {
-        var filename = 'test/support/resources' + request.url; 
+        var filename = 'test/support/resources' + request.url;
         fs.readFile(filename, "binary", function(err, file) {
           if ( err ) {
             response.writeHead(404, {'Content-Type': 'text/plain'});
@@ -69,11 +69,11 @@ suite('mml_builder', function() {
             .toXML(done);
     });
 
-  test('can be initialized with custom interactivity', function(done) {
-    var mml_store = new grainstore.MMLStore({mapnik_version: '2.1.0'});
-    mml_store.mml_builder({dbname: 'd', sql: SAMPLE_SQL, style: DEFAULT_POINT_STYLE, interactivity: 'cartodb_id' })
-        .toXML(done);
-  });
+    test('can be initialized with custom interactivity', function(done) {
+        var mml_store = new grainstore.MMLStore({mapnik_version: '2.1.0'});
+        mml_store.mml_builder({dbname: 'd', sql: SAMPLE_SQL, style: DEFAULT_POINT_STYLE, interactivity: 'cartodb_id' })
+            .toXML(done);
+    });
 
     test('can generate base mml with overridden authentication', function(done) {
         var mml_store = new grainstore.MMLStore({
@@ -170,7 +170,7 @@ suite('mml_builder', function() {
         done();
     });
 
-  // See https://github.com/CartoDB/grainstore/issues/70
+    // See https://github.com/CartoDB/grainstore/issues/70
     test('can override db host and port with mml_builder constructor', function(done) {
         var mml_store = new grainstore.MMLStore({
             datasource: { host:'shadow_host', port:'shadow_port' }});
@@ -680,6 +680,7 @@ suite('mml_builder', function() {
         if ( err ) {
             throw err;
         }
+        console.log(data);
         var xmlDoc = libxmljs.parseXmlString(data);
         var node = xmlDoc.find("//Filter");
         assert.equal(node.length, 3);
@@ -708,7 +709,7 @@ suite('mml_builder', function() {
 
   test('can construct mml_builder', function(done) {
     var style = '#t {bogus}';
-    // NOTE: we need mapnik_version to be != 2.0.0 
+    // NOTE: we need mapnik_version to be != 2.0.0
     var mml_store = new grainstore.MMLStore({mapnik_version: '2.1.0'});
     mml_store.mml_builder({dbname: 'd', sql:'t', style: style}).toXML(
         function checkInit_getXML(err) {
@@ -749,5 +750,37 @@ suite('mml_builder', function() {
       }
     );
   });
+
+    test('should can set format after building the MML', function(done) {
+        var mml_store = new grainstore.MMLStore();
+        var mml = mml_store.mml_builder({
+            dbname: 'my_databaasez',
+            sql: SAMPLE_SQL,
+            style: DEFAULT_POINT_STYLE
+        });
+
+        mml.set('grainstore_map', { format: 'png32' });
+
+        mml.toXML(function (err, data) {
+            var xmlDoc = libxmljs.parseXmlString(data);
+            var format = xmlDoc.get("//Parameter[@name='format']");
+
+            assert.equal(format.text(), 'png32');
+            done();
+        });
+    });
+
+    test('when setting a property not allowed should throw error', function () {
+        var mml_store = new grainstore.MMLStore();
+        var mml = mml_store.mml_builder({
+            dbname: 'my_databaasez',
+            sql: SAMPLE_SQL,
+            style: DEFAULT_POINT_STYLE
+        });
+
+        assert.throws(function() {
+            mml.set('toXML', { format: 'png32' });
+        }, Error);
+    });
 
 });


### PR DESCRIPTION
In some scenarios would be very useful be able to change the way to generate the MML after it was created. Now MML builder has a setter function that can be used in order to, for example, change the  format.