### PR TITLE
[mapnik-3] Supports mapnik reference 3.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,15 @@ node_js:
   - "0.10"
   - "0.12"
   - "6"
+
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
+
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "6"

--- a/lib/grainstore/mml_builder.js
+++ b/lib/grainstore/mml_builder.js
@@ -218,11 +218,10 @@ MMLBuilder.prototype.render = function(style_in, version, callback){
         // See https://github.com/mapbox/carto/pull/187
         try {
             var r = new carto.Renderer(carto_env, carto_options);
-            r.render(mml, function(err, output){
-                callback(err, output);
-            });
-        } catch (err) {
-            callback(err, null);
+            var output = r.render(mml);
+            callback(null, output);
+        } catch (e) {
+            callback(e, null);
         }
     });
 };

--- a/lib/grainstore/paths/from20To21.js
+++ b/lib/grainstore/paths/from20To21.js
@@ -1,0 +1,133 @@
+'use strict';
+
+var _ = require('underscore');
+var semver = require('semver');
+
+module.exports = function convert_20_to_21(style, from, to) {
+    // strip comments from styles
+    // NOTE: these regexp will make a mess when comment-looking strings are put
+    //       in quoted strings. We take the risk, assuming it'd be very uncommon
+    //       to find literal in styles anyway...
+    //console.log("X: " + style);
+    style = style.replace(new RegExp('(/\\*[^\*]*\\*/)|(//.*\n)', 'g'), '');
+    //console.log("Y: " + style);
+
+    var global_marker_directives = [];
+    var global_has_marker_directives = false;
+    var re = new RegExp('([^{]*){([^}]*)}', 'g');
+    var newstyle = style.replace(re, function(mtc, cond, stl) {
+        // trim blank spaces (but not newlines) on both sides
+        stl = stl.replace(/^[ \t]*/, '').replace(/[\t ]*$/, '');
+        // add ending newline, if missing
+        if (/[^\s]/.exec(stl) && !/;\s*$/.exec(stl)) stl += ';';
+        var append = '';
+
+        var is_global_block = !/]\s*$/.exec(cond);
+        var has_marker_directives = global_has_marker_directives;
+        var re = new RegExp('(marker-[^\s:]*):\s*([^;}]*)', "ig");
+        var marker_directives = is_global_block ? global_marker_directives : _.defaults([], global_marker_directives);
+        var stl = stl.replace(re, function(m, l, v) {
+            l = l.toLowerCase();
+            if (!marker_directives.hasOwnProperty(l)) {
+                marker_directives[l] = v;
+            }
+            has_marker_directives = true;
+            if (is_global_block) {
+                global_has_marker_directives = true;
+            }
+
+            // In mapnik-2.0.x, marker-opacity only set opacity of the marker
+            // fill (but not stroke). This is equivalent to the mapnik-2.1.x
+            // directive ``marker-fill-opacity``. We want to translate the
+            // directive name beause ``marker-opacity`` also sets stroke
+            // opacity with mapnik-2.1.x.
+            //
+            // See https://github.com/Vizzuality/grainstore/issues/40
+            //
+            m = m.replace(new RegExp('marker-opacity', 'i'), 'marker-fill-opacity');
+
+            return m;
+        });
+
+        // We want to match "line-anything" but not "-line-anything"
+        // See https://github.com/Vizzuality/grainstore/issues/37
+        var has_line_directives = /[\s{;]line-[^\s:]*\s*:/.exec(' ' + stl);
+        var has_poly_directives = /[\s{;]polygon-[^\s:]*\s*/.exec(' ' + stl);
+
+        // Double marker-width and marker-height but not if source is '2.0.1'
+        // TODO: put within has_marker_directives
+        if (from !== '2.0.1') {
+            var re = new RegExp('marker-(width|height)[\t\n ]*:[\t\n ]*(["\']?)([^\'";}]*)["\']?\\b', 'g');
+            stl = stl.replace(re, function(m, l, q, v) {
+                return 'marker-' + l + ':' + q + (v * 2);
+            });
+        }
+
+        //console.log("Has marker directives: " + has_marker_directives );
+
+        // Set marker-related defaults but only if any
+        // "marker-xxx" directive is given
+        if (has_marker_directives) {
+
+            // For points, set:
+            //  marker-placement:point (in 2.1.0 marker-placement:line doesn't work with points)
+            //  marker-type:ellipse (in 2.0.0 marker-type:arrow didn't work with points)
+            append += ' ["mapnik::geometry_type"=1] { marker-placement:point; marker-type:ellipse; }';
+
+            var line_poly_override = ' ["mapnik::geometry_type">1] { ';
+
+            // Set marker-placement:line for lines and polys
+            // but only if a marker-placement isn't already present
+            if (!marker_directives['marker-placement']) {
+                line_poly_override += 'marker-placement:line; ';
+            }
+
+            var has_arrow_marker = (marker_directives['marker_type'] === 'arrow');
+
+            // Set to marker-type:arrow for lines and polys
+            // but only if a marker-type isn't already present and
+            // the marker-placement directive requests a point (didn't work in 2.0)
+            if (!marker_directives['marker-type'] && marker_directives['marker-placement'] !== 'point') {
+                line_poly_override += 'marker-type:arrow; ';
+                has_arrow_marker = true;
+            }
+
+            // See https://github.com/mapnik/mapnik/issues/1591#issuecomment-10740221
+            if (has_arrow_marker) {
+                line_poly_override += 'marker-transform:scale(.5, .5); ';
+            }
+
+            // If the marker-placement directive requested a point we'll use ellipse marker-type
+            // as 2.0 didn't work with arrows and points..
+            if (marker_directives['marker-placement'] === 'point') {
+                line_poly_override += 'marker-type:ellipse; ';
+            }
+
+            // 2.0.0 did not clip geometries before sending
+            // to style renderer
+            line_poly_override += 'marker-clip:false; ';
+
+            line_poly_override += '}';
+
+            append += line_poly_override;
+
+            if (semver.satisfies(to, "~2.1.1")) {
+                // See https://github.com/Vizzuality/grainstore/issues/36
+                append += ' marker-multi-policy:whole;';
+            }
+        }
+
+        //console.log("STYLE: [" + style + "]");
+        //console.log("  STL: [" + stl + "]");
+
+        var newblock = cond + '{ ' + stl + append + ' }';
+
+        return newblock;
+    });
+
+    //console.log("PRE:"); console.log(style);
+    style = newstyle;
+    //console.log("POS:"); console.log(style);
+
+    return style;
+};

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -22,7 +22,10 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
         css.walkRules(function (rule) {
             symbolyzers.forEach(function (symbolyzer) {
                 setClipDefaultToTrue(rule, symbolyzer);
-                setPatternAlignmentDefaultToLocal(rule, symbolyzer);
+                
+                if (symbolizer === 'polygon') {
+                    setPatternAlignmentDefaultToLocal(rule, symbolyzer);
+                }
             });
         });
     };
@@ -38,10 +41,6 @@ function setClipDefaultToTrue(rule, symbolizer) {
 }
 
 function setPatternAlignmentDefaultToLocal(rule, symbolizer) {
-    if (symbolizer !== 'polygon') {
-        return;
-    }
-
     var property = [symbolizer, 'pattern-aligment'].join('-');
 
     if (hasPropertySymbolyzer(rule, symbolizer) && !hasPropertyAlreadyDefined(rule, property)) {

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -1,14 +1,49 @@
 'use strict';
 
 var postcss = require('postcss');
-var symbolizers = {
-    POLYGON: 'polygon',
-    LINE: 'line',
-    MARKER: 'marker',
-    SHIELD: 'shield',
-    TEXT: 'text',
-    BUILDING: 'building'
-};
+var propertyDefaultValues = [{
+    symbolizer: 'polygon',
+    defaults: [{
+        property: 'polygon-clip',
+        value: true
+    }, {
+        property: 'polygon-pattern-aligment',
+        value: 'local'
+    }]
+}, {
+    symbolizer: 'line',
+    defaults: [{
+        property: 'line-clip',
+        value: true
+    }]
+}, {
+    symbolizer: 'marker',
+    defaults: [{
+        property: 'marker-clip',
+        value: true
+    }]
+}, {
+    symbolizer: 'shield',
+    defaults: [{
+        property: 'shield-clip',
+        value: true
+    }]
+}, {
+    symbolizer: 'text',
+    defaults: [{
+        property: 'text-clip',
+        value: true
+    }, {
+        property: 'text-label-position-tolerance',
+        value: 0
+    }]
+}, {
+    symbolizer: 'building',
+    defaults: [{
+        property: 'building-fill',
+        value: 'white'
+    }]
+}];
 
 module.exports = function (cartoCss) {
     return postcss()
@@ -21,26 +56,16 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
     options = options || {};
     return function (css) {
         css.walkRules(function (rule) {
-            setPropertyToDefault(rule, symbolizers.POLYGON, 'clip', true);
-            setPropertyToDefault(rule, symbolizers.POLYGON, 'pattern-aligment', 'local');
-
-            setPropertyToDefault(rule, symbolizers.LINE, 'clip', true);
-
-            setPropertyToDefault(rule, symbolizers.MARKER, 'clip', true);
-
-            setPropertyToDefault(rule, symbolizers.SHIELD, 'clip', true);
-
-            setPropertyToDefault(rule, symbolizers.TEXT, 'clip', true);
-            setPropertyToDefault(rule, symbolizers.TEXT, 'label-position-tolerance', 0);
-
-            setPropertyToDefault(rule, symbolizers.BUILDING, 'fill', 'white');
+            propertyDefaultValues.forEach(function (property) {
+                property.defaults.forEach(function (propertyDefault) {
+                    setPropertyToDefault(rule, property.symbolizer, propertyDefault.property, propertyDefault.value);
+                });
+            });
         });
     };
 });
 
-function setPropertyToDefault(rule, symbolizer, propSuffix, defaultValue) {
-    var property = [symbolizer, propSuffix].join('-');
-
+function setPropertyToDefault(rule, symbolizer, property, defaultValue) {
     if (hasDeclWithSymbolyzer(rule, symbolizer) && !hasPropertyDefined(rule, property)) {
         var patternAlignmentDecl = postcss.decl({ prop: property, value: defaultValue });
         rule.append(patternAlignmentDecl);

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -5,15 +5,13 @@ var postcss = require('postcss');
 var stripSingleLineComments = require('strip-css-singleline-comments/sync');
 
 var propertyDefaultValues = [{
-    symbolizer: 'polygon',
-    matches: /^polygon-(?!pattern-)/,
+    symbolizer: /^polygon-(?!pattern-)/,
     defaults: [{
         property: 'polygon-clip',
         value: true
     }]
 }, {
-    symbolizer: 'polygon-pattern',
-    matches: /^polygon-pattern-/,
+    symbolizer: /^polygon-pattern-/,
     defaults: [{
         property: 'polygon-pattern-clip',
         value: true
@@ -22,36 +20,34 @@ var propertyDefaultValues = [{
         value: 'local'
     }]
 }, {
-    symbolizer: 'line',
-    matches: /^line-(?!pattern-)/,
+    symbolizer: /^line-(?!pattern-)/,
     defaults: [{
         property: 'line-clip',
         value: true
     }]
 }, {
-    symbolizer: 'line-pattern',
-    matches: /^line-pattern-/,
+    symbolizer: /^line-pattern-/,
     defaults: [{
         property: 'line-pattern-clip',
         value: true
     }]
 }, {
-    symbolizer: 'marker',
-    matches: /^marker-/,
+    symbolizer: /^marker-/,
     defaults: [{
         property: 'marker-clip',
         value: true
+    }, {
+        property: 'marker-line-width',
+        value: 1
     }]
 }, {
-    symbolizer: 'shield',
-    matches: /^shield-/,
+    symbolizer: /^shield-/,
     defaults: [{
         property: 'shield-clip',
         value: true
     }]
 }, {
-    symbolizer: 'text',
-    matches: /^text-/,
+    symbolizer: /^text-/,
     defaults: [{
         property: 'text-clip',
         value: true
@@ -60,8 +56,7 @@ var propertyDefaultValues = [{
         value: 0
     }]
 }, {
-    symbolizer: 'building',
-    matches: /^building-/,
+    symbolizer: /^building-/,
     defaults: [{
         property: 'building-fill',
         value: 'white'
@@ -82,15 +77,15 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
             debug('Inspecting selector "%s"', rule.selector);
             propertyDefaultValues.forEach(function (property) {
                 property.defaults.forEach(function (propertyDefault) {
-                    setPropertyToDefault(rule, property.symbolizer, property.matches, propertyDefault.property, propertyDefault.value);
+                    setPropertyToDefault(rule, property.symbolizer, propertyDefault.property, propertyDefault.value);
                 });
             });
         });
     };
 });
 
-function setPropertyToDefault(rule, symbolizer, matches, property, defaultValue) {
-    if (hasDeclWithSymbolyzer(rule, symbolizer, matches) && !hasPropertyDefined(rule, property)) {
+function setPropertyToDefault(rule, symbolizer, property, defaultValue) {
+    if (hasDeclWithSymbolyzer(rule, symbolizer) && !hasPropertyDefined(rule, property)) {
         var declaration = postcss.decl({ prop: property, value: defaultValue });
         rule.append(declaration);
         debug('Appending declaration "%s: %s" to selector "%s"', property, defaultValue, rule.selector);
@@ -112,13 +107,13 @@ function hasPropertyDefined(rule, property) {
     return hasPropertyDefined;
 }
 
-function hasDeclWithSymbolyzer(rule, symbolyzer, matches) {
+function hasDeclWithSymbolyzer(rule, symbolyzer) {
     var hasPropertySymbolyzer = false;
 
     rule.walkDecls(function (decl) {
         if (decl.parent === rule) {
-            debug('Inspecting declaration "%s" to check if it has any property that belongs to "%s" symbolizer', decl.toString(), symbolyzer);
-            if (decl.prop.match(matches)) {
+            debug('Inspecting declaration "%s" to check if it has any property that belongs to "%s" symbolizer', decl.toString(), symbolyzer.toString());
+            if (decl.prop.match(symbolyzer)) {
                 hasPropertySymbolyzer = true;
             }
         }

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -23,7 +23,7 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
             symbolyzers.forEach(function (symbolizer) {
                 setPropertyToDefault(rule, symbolizer, 'clip', true);
             });
-            
+
             setPropertyToDefault(rule, 'polygon', 'pattern-aligment', 'local');
         });
     };
@@ -32,26 +32,25 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
 function setPropertyToDefault(rule, symbolizer, propSuffix, defaultValue) {
     var property = [symbolizer, propSuffix].join('-');
 
-    if (hasPropertySymbolyzer(rule, symbolizer) && !hasPropertyAlreadyDefined(rule, property)) {
+    if (hasDeclWithSymbolyzer(rule, symbolizer) && !hasPropertyDefined(rule, property)) {
         var patternAlignmentDecl = postcss.decl({ prop: property, value: defaultValue });
         rule.append(patternAlignmentDecl);
     }
 }
 
-function hasPropertyAlreadyDefined(rule, property) {
-    var hasPropertyAlreadyDefined = false;
+function hasPropertyDefined(rule, property) {
+    var hasPropertyDefined = false;
 
     rule.walkDecls(function (decl) {
         if (decl.prop === property) {
-            hasPropertyAlreadyDefined = true;
+            hasPropertyDefined = true;
         }
     });
 
-    return hasPropertyAlreadyDefined;
+    return hasPropertyDefined;
 }
 
-
-function hasPropertySymbolyzer(rule, symbolyzer) {
+function hasDeclWithSymbolyzer(rule, symbolyzer) {
     var hasPropertySymbolyzer = false;
 
     rule.walkDecls(function (decl) {

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -7,6 +7,12 @@ var propertyDefaultValues = [{
     defaults: [{
         property: 'polygon-clip',
         value: true
+    }]
+}, {
+    symbolizer: 'polygon-pattern',
+    defaults: [{
+        property: 'polygon-pattern-clip',
+        value: true
     }, {
         property: 'polygon-pattern-aligment',
         value: 'local'
@@ -15,6 +21,12 @@ var propertyDefaultValues = [{
     symbolizer: 'line',
     defaults: [{
         property: 'line-clip',
+        value: true
+    }]
+}, {
+    symbolizer: 'line-pattern',
+    defaults: [{
+        property: 'line-pattern-clip',
         value: true
     }]
 }, {
@@ -45,6 +57,10 @@ var propertyDefaultValues = [{
         value: 'white'
     }]
 }];
+
+var symbolizers = propertyDefaultValues.map(function (propertyDefaultValue) {
+    return propertyDefaultValue.symbolizer;
+})
 
 module.exports = function (cartoCss) {
     return postcss()
@@ -92,10 +108,25 @@ function hasDeclWithSymbolyzer(rule, symbolyzer) {
     rule.walkDecls(function (decl) {
         var property = decl.prop;
 
-        if (property.indexOf(symbolyzer) === 0) {
+        if (property.indexOf(symbolyzer) === 0 && !isIncludedInOtherSymbolyzers(symbolyzer, property)) {
             hasPropertySymbolyzer = true;
         }
     });
 
     return hasPropertySymbolyzer;
+}
+
+function isIncludedInOtherSymbolyzers(symbolyzer, property) {
+    var isIncluded = false;
+    var otherSymbolizers = symbolizers.filter(function (_symbolizer) {
+        return _symbolizer !== symbolyzer;
+    });
+
+    otherSymbolizers.forEach(function (otherSymbolizer) {
+        if (property.indexOf(otherSymbolizer) === 0 && otherSymbolizer.length > symbolyzer.length) {
+            isIncluded = true;
+        }
+    });
+
+    return isIncluded;
 }

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -98,12 +98,11 @@ function setPropertyToDefault(rule, symbolizer, property, defaultValue) {
 function hasPropertyDefined(rule, property) {
     var hasPropertyDefined = false;
 
-    rule.walkDecls(function (decl) {
+    rule.walkDecls(property, function (decl) {
+        debug('Inspecting declaration "%s" to check if "%s" is already defined', decl, property);
+
         if (decl.parent === rule) {
-            debug('Inspecting declaration "%s" to check if "%s" is already defined', decl, property);
-            if (decl.prop === property) {
-                hasPropertyDefined = true;
-            }
+            hasPropertyDefined = true;
         }
     });
 
@@ -113,12 +112,11 @@ function hasPropertyDefined(rule, property) {
 function hasDeclWithSymbolyzer(rule, symbolyzer) {
     var hasPropertySymbolyzer = false;
 
-    rule.walkDecls(function (decl) {
+    rule.walkDecls(symbolyzer, function (decl) {
+        debug('Inspecting declaration "%s" to check if it has any property that belongs to "%s" symbolizer', decl, symbolyzer);
+
         if (decl.parent === rule) {
-            debug('Inspecting declaration "%s" to check if it has any property that belongs to "%s" symbolizer', decl, symbolyzer);
-            if (decl.prop.match(symbolyzer)) {
-                hasPropertySymbolyzer = true;
-            }
+            hasPropertySymbolyzer = true;
         }
     });
 

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var postcss = require('postcss');
+var symbolyzers = [
+    'polygon',
+    'line',
+    'marker',
+    'shield',
+    'text'
+];
+
+module.exports = function (cartoCss) {
+    return postcss()
+        .use(postcssCartocssMigrator())
+        .process(cartoCss)
+        .css;
+};
+
+var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', function (options) {
+    options = options || {};
+    return function (css) {
+        css.walkRules(function (rule) {
+            symbolyzers.forEach(function (symbolyzer) {
+                setClipDefaultToTrue(rule, symbolyzer);
+            });
+        });
+    };
+});
+
+function setClipDefaultToTrue(rule, symbolizer) {
+    if (!hasClipToTrue(rule, symbolizer) && hasPropertySymbolyzer(rule, symbolizer)) {
+        var clipDecl = postcss.decl({ prop: symbolizer + '-clip', value: true });
+        rule.append(clipDecl);
+    }
+}
+
+function hasClipToTrue(rule, symbolyzer) {
+    var clipProperty = symbolyzer + '-clip';
+    var hasClipToTrue = false;
+
+    rule.walkDecls(function (decl) {
+        var property = decl.prop;
+        var value =  decl.value;
+
+        if (property === clipProperty && value === 'true') {
+            hasClipToTrue = true;
+        }
+    });
+
+    return hasClipToTrue;
+}
+
+function hasPropertySymbolyzer(rule, symbolyzer) {
+    var hasPropertySymbolyzer = false;
+
+    rule.walkDecls(function (decl) {
+        var property = decl.prop;
+
+        if (property.indexOf(symbolyzer) === 0) {
+            hasPropertySymbolyzer = true;
+        }
+    });
+
+    return hasPropertySymbolyzer;
+}

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -36,7 +36,10 @@ var propertyDefaultValues = [{
     defaults: [{
         property: 'marker-clip',
         value: true
-    }, {
+    }]
+}, {
+    symbolizer: /^marker-line-/,
+    defaults: [{
         property: 'marker-line-width',
         value: 1
     }]

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -21,30 +21,19 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
     return function (css) {
         css.walkRules(function (rule) {
             symbolyzers.forEach(function (symbolizer) {
-                setClipDefaultToTrue(rule, symbolizer);
-
-                if (symbolizer === 'polygon') {
-                    setPatternAlignmentDefaultToLocal(rule, symbolizer);
-                }
+                setPropertyToDefault(rule, symbolizer, 'clip', true);
             });
+            
+            setPropertyToDefault(rule, 'polygon', 'pattern-aligment', 'local');
         });
     };
 });
 
-function setClipDefaultToTrue(rule, symbolizer) {
-    var property = [symbolizer, 'clip'].join('-');
+function setPropertyToDefault(rule, symbolizer, propSuffix, defaultValue) {
+    var property = [symbolizer, propSuffix].join('-');
 
     if (hasPropertySymbolyzer(rule, symbolizer) && !hasPropertyAlreadyDefined(rule, property)) {
-        var clipDecl = postcss.decl({ prop: property, value: true });
-        rule.append(clipDecl);
-    }
-}
-
-function setPatternAlignmentDefaultToLocal(rule, symbolizer) {
-    var property = [symbolizer, 'pattern-aligment'].join('-');
-
-    if (hasPropertySymbolyzer(rule, symbolizer) && !hasPropertyAlreadyDefined(rule, property)) {
-        var patternAlignmentDecl = postcss.decl({ prop: property, value: 'local' });
+        var patternAlignmentDecl = postcss.decl({ prop: property, value: defaultValue });
         rule.append(patternAlignmentDecl);
     }
 }

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -100,7 +100,7 @@ function hasPropertyDefined(rule, property) {
 
     rule.walkDecls(function (decl) {
         if (decl.parent === rule) {
-            debug('Inspecting declaration "%s" to check if "%s" is already defined', decl.toString(), property);
+            debug('Inspecting declaration "%s" to check if "%s" is already defined', decl, property);
             if (decl.prop === property) {
                 hasPropertyDefined = true;
             }
@@ -115,7 +115,7 @@ function hasDeclWithSymbolyzer(rule, symbolyzer) {
 
     rule.walkDecls(function (decl) {
         if (decl.parent === rule) {
-            debug('Inspecting declaration "%s" to check if it has any property that belongs to "%s" symbolizer', decl.toString(), symbolyzer.toString());
+            debug('Inspecting declaration "%s" to check if it has any property that belongs to "%s" symbolizer', decl, symbolyzer);
             if (decl.prop.match(symbolyzer)) {
                 hasPropertySymbolyzer = true;
             }

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -66,10 +66,6 @@ var propertyDefaultValues = [{
     }]
 }];
 
-var symbolizers = propertyDefaultValues.map(function (propertyDefaultValue) {
-    return propertyDefaultValue.symbolizer;
-})
-
 module.exports = function (cartoCss) {
     return postcss()
         .use(postcssCartocssMigrator())

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -28,26 +28,26 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
 });
 
 function setClipDefaultToTrue(rule, symbolizer) {
-    if (!hasClipToTrue(rule, symbolizer) && hasPropertySymbolyzer(rule, symbolizer)) {
+    if (!hasClipAlreadyDefined(rule, symbolizer) && hasPropertySymbolyzer(rule, symbolizer)) {
         var clipDecl = postcss.decl({ prop: symbolizer + '-clip', value: true });
         rule.append(clipDecl);
     }
 }
 
-function hasClipToTrue(rule, symbolyzer) {
+function hasClipAlreadyDefined(rule, symbolyzer) {
     var clipProperty = symbolyzer + '-clip';
-    var hasClipToTrue = false;
+    var hasClipDefined = false;
 
     rule.walkDecls(function (decl) {
         var property = decl.prop;
         var value =  decl.value;
 
-        if (property === clipProperty && value === 'true') {
-            hasClipToTrue = true;
+        if (property === clipProperty) {
+            hasClipDefined = true;
         }
     });
 
-    return hasClipToTrue;
+    return hasClipDefined;
 }
 
 function hasPropertySymbolyzer(rule, symbolyzer) {

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -71,8 +71,8 @@ module.exports = function (cartoCss) {
 
 var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', function (options) {
     options = options || {};
-    return function (css) {
-        css.walkRules(function (rule) {
+    return function (root) {
+        root.walkRules(function (rule) {
             propertyDefaultValues.forEach(function (property) {
                 property.defaults.forEach(function (propertyDefault) {
                     setPropertyToDefault(rule, property.symbolizer, propertyDefault.property, propertyDefault.value);

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var debug = require('debug')('grainstore:transform');
 var postcss = require('postcss');
 var propertyDefaultValues = [{
     symbolizer: 'polygon',
@@ -67,8 +68,9 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
 
 function setPropertyToDefault(rule, symbolizer, property, defaultValue) {
     if (hasDeclWithSymbolyzer(rule, symbolizer) && !hasPropertyDefined(rule, property)) {
-        var patternAlignmentDecl = postcss.decl({ prop: property, value: defaultValue });
-        rule.append(patternAlignmentDecl);
+        var declaration = postcss.decl({ prop: property, value: defaultValue });
+        rule.append(declaration);
+        debug('Appending declaration "%s: %s" to selector "%s"', property, defaultValue, rule.selector);
     }
 }
 

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -114,9 +114,7 @@ function hasDeclWithSymbolyzer(rule, symbolyzer, matches) {
     var hasPropertySymbolyzer = false;
 
     rule.walkDecls(function (decl) {
-        var property = decl.prop;
-
-        if (property.match(matches)) {
+        if (decl.prop.match(matches)) {
             hasPropertySymbolyzer = true;
         }
     });

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -2,6 +2,8 @@
 
 var debug = require('debug')('grainstore:transform');
 var postcss = require('postcss');
+var stripSingleLineComments = require('strip-css-singleline-comments/sync');
+
 var propertyDefaultValues = [{
     symbolizer: 'polygon',
     matches: /^polygon-(?!pattern-)/,
@@ -69,7 +71,7 @@ var propertyDefaultValues = [{
 module.exports = function (cartoCss) {
     return postcss()
         .use(postcssCartocssMigrator())
-        .process(cartoCss)
+        .process(stripSingleLineComments(cartoCss))
         .css;
 };
 

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -6,7 +6,8 @@ var symbolizers = {
     LINE: 'line',
     MARKER: 'marker',
     SHIELD: 'shield',
-    TEXT: 'text'
+    TEXT: 'text',
+    BUILDING: 'building'
 };
 
 module.exports = function (cartoCss) {
@@ -20,12 +21,19 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
     options = options || {};
     return function (css) {
         css.walkRules(function (rule) {
-            Object.keys(symbolizers).forEach(function (key) {
-                setPropertyToDefault(rule, symbolizers[key], 'clip', true);
-            });
-
+            setPropertyToDefault(rule, symbolizers.POLYGON, 'clip', true);
             setPropertyToDefault(rule, symbolizers.POLYGON, 'pattern-aligment', 'local');
+
+            setPropertyToDefault(rule, symbolizers.LINE, 'clip', true);
+
+            setPropertyToDefault(rule, symbolizers.MARKER, 'clip', true);
+
+            setPropertyToDefault(rule, symbolizers.SHIELD, 'clip', true);
+
+            setPropertyToDefault(rule, symbolizers.TEXT, 'clip', true);
             setPropertyToDefault(rule, symbolizers.TEXT, 'label-position-tolerance', 0);
+
+            setPropertyToDefault(rule, symbolizers.BUILDING, 'fill', 'white');
         });
     };
 });

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -20,11 +20,11 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
     options = options || {};
     return function (css) {
         css.walkRules(function (rule) {
-            symbolyzers.forEach(function (symbolyzer) {
-                setClipDefaultToTrue(rule, symbolyzer);
-                
+            symbolyzers.forEach(function (symbolizer) {
+                setClipDefaultToTrue(rule, symbolizer);
+
                 if (symbolizer === 'polygon') {
-                    setPatternAlignmentDefaultToLocal(rule, symbolyzer);
+                    setPatternAlignmentDefaultToLocal(rule, symbolizer);
                 }
             });
         });

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -32,7 +32,7 @@ function setClipDefaultToTrue(rule, symbolizer) {
     var property = [symbolizer, 'clip'].join('-');
 
     if (hasPropertySymbolyzer(rule, symbolizer) && !hasPropertyAlreadyDefined(rule, property)) {
-        var clipDecl = postcss.decl({ prop: symbolizer + '-clip', value: true });
+        var clipDecl = postcss.decl({ prop: property, value: true });
         rule.append(clipDecl);
     }
 }
@@ -45,7 +45,7 @@ function setPatternAlignmentDefaultToLocal(rule, symbolizer) {
     var property = [symbolizer, 'pattern-aligment'].join('-');
 
     if (hasPropertySymbolyzer(rule, symbolizer) && !hasPropertyAlreadyDefined(rule, property)) {
-        var patternAlignmentDecl = postcss.decl({ prop: symbolizer + '-pattern-aligment', value: 'local' });
+        var patternAlignmentDecl = postcss.decl({ prop: property, value: 'local' });
         rule.append(patternAlignmentDecl);
     }
 }

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -4,12 +4,14 @@ var debug = require('debug')('grainstore:transform');
 var postcss = require('postcss');
 var propertyDefaultValues = [{
     symbolizer: 'polygon',
+    matches: /^polygon-(?!pattern-)/,
     defaults: [{
         property: 'polygon-clip',
         value: true
     }]
 }, {
     symbolizer: 'polygon-pattern',
+    matches: /^polygon-pattern-/,
     defaults: [{
         property: 'polygon-pattern-clip',
         value: true
@@ -19,30 +21,35 @@ var propertyDefaultValues = [{
     }]
 }, {
     symbolizer: 'line',
+    matches: /^line-(?!pattern-)/,
     defaults: [{
         property: 'line-clip',
         value: true
     }]
 }, {
     symbolizer: 'line-pattern',
+    matches: /^line-pattern-/,
     defaults: [{
         property: 'line-pattern-clip',
         value: true
     }]
 }, {
     symbolizer: 'marker',
+    matches: /^marker-/,
     defaults: [{
         property: 'marker-clip',
         value: true
     }]
 }, {
     symbolizer: 'shield',
+    matches: /^shield-/,
     defaults: [{
         property: 'shield-clip',
         value: true
     }]
 }, {
     symbolizer: 'text',
+    matches: /^text-/,
     defaults: [{
         property: 'text-clip',
         value: true
@@ -52,6 +59,7 @@ var propertyDefaultValues = [{
     }]
 }, {
     symbolizer: 'building',
+    matches: /^building-/,
     defaults: [{
         property: 'building-fill',
         value: 'white'
@@ -75,15 +83,15 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
         root.walkRules(function (rule) {
             propertyDefaultValues.forEach(function (property) {
                 property.defaults.forEach(function (propertyDefault) {
-                    setPropertyToDefault(rule, property.symbolizer, propertyDefault.property, propertyDefault.value);
+                    setPropertyToDefault(rule, property.symbolizer, property.matches, propertyDefault.property, propertyDefault.value);
                 });
             });
         });
     };
 });
 
-function setPropertyToDefault(rule, symbolizer, property, defaultValue) {
-    if (hasDeclWithSymbolyzer(rule, symbolizer) && !hasPropertyDefined(rule, property)) {
+function setPropertyToDefault(rule, symbolizer, matches, property, defaultValue) {
+    if (hasDeclWithSymbolyzer(rule, symbolizer, matches) && !hasPropertyDefined(rule, property)) {
         var declaration = postcss.decl({ prop: property, value: defaultValue });
         rule.append(declaration);
         debug('Appending declaration "%s: %s" to selector "%s"', property, defaultValue, rule.selector);
@@ -102,31 +110,16 @@ function hasPropertyDefined(rule, property) {
     return hasPropertyDefined;
 }
 
-function hasDeclWithSymbolyzer(rule, symbolyzer) {
+function hasDeclWithSymbolyzer(rule, symbolyzer, matches) {
     var hasPropertySymbolyzer = false;
 
     rule.walkDecls(function (decl) {
         var property = decl.prop;
 
-        if (property.indexOf(symbolyzer) === 0 && !isIncludedInOtherSymbolyzers(symbolyzer, property)) {
+        if (property.match(matches)) {
             hasPropertySymbolyzer = true;
         }
     });
 
     return hasPropertySymbolyzer;
-}
-
-function isIncludedInOtherSymbolyzers(symbolyzer, property) {
-    var isIncluded = false;
-    var otherSymbolizers = symbolizers.filter(function (_symbolizer) {
-        return _symbolizer !== symbolyzer;
-    });
-
-    otherSymbolizers.forEach(function (otherSymbolizer) {
-        if (property.indexOf(otherSymbolizer) === 0 && otherSymbolizer.length > symbolyzer.length) {
-            isIncluded = true;
-        }
-    });
-
-    return isIncluded;
 }

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -77,6 +77,7 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
     options = options || {};
     return function (root) {
         root.walkRules(function (rule) {
+            debug('Inspecting selector "%s"', rule.selector);
             propertyDefaultValues.forEach(function (property) {
                 property.defaults.forEach(function (propertyDefault) {
                     setPropertyToDefault(rule, property.symbolizer, property.matches, propertyDefault.property, propertyDefault.value);
@@ -98,8 +99,11 @@ function hasPropertyDefined(rule, property) {
     var hasPropertyDefined = false;
 
     rule.walkDecls(function (decl) {
-        if (decl.prop === property) {
-            hasPropertyDefined = true;
+        if (decl.parent === rule) {
+            debug('Inspecting declaration "%s" to check if "%s" is already defined', decl.toString(), property);
+            if (decl.prop === property) {
+                hasPropertyDefined = true;
+            }
         }
     });
 
@@ -110,8 +114,11 @@ function hasDeclWithSymbolyzer(rule, symbolyzer, matches) {
     var hasPropertySymbolyzer = false;
 
     rule.walkDecls(function (decl) {
-        if (decl.prop.match(matches)) {
-            hasPropertySymbolyzer = true;
+        if (decl.parent === rule) {
+            debug('Inspecting declaration "%s" to check if it has any property that belongs to "%s" symbolizer', decl.toString(), symbolyzer);
+            if (decl.prop.match(matches)) {
+                hasPropertySymbolyzer = true;
+            }
         }
     });
 

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -29,26 +29,10 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
 });
 
 function setClipDefaultToTrue(rule, symbolizer) {
-    if (!hasClipAlreadyDefined(rule, symbolizer) && hasPropertySymbolyzer(rule, symbolizer)) {
+    if (!hasPropertyAlreadyDefined(rule, symbolizer, 'clip') && hasPropertySymbolyzer(rule, symbolizer)) {
         var clipDecl = postcss.decl({ prop: symbolizer + '-clip', value: true });
         rule.append(clipDecl);
     }
-}
-
-function hasClipAlreadyDefined(rule, symbolyzer) {
-    var clipProperty = symbolyzer + '-clip';
-    var hasClipDefined = false;
-
-    rule.walkDecls(function (decl) {
-        var property = decl.prop;
-        var value =  decl.value;
-
-        if (property === clipProperty) {
-            hasClipDefined = true;
-        }
-    });
-
-    return hasClipDefined;
 }
 
 function setPatternAlignmentDefaultToLocal(rule, symbolizer) {
@@ -56,27 +40,25 @@ function setPatternAlignmentDefaultToLocal(rule, symbolizer) {
         return;
     }
 
-    if (!hasPatternAlignmentAlreadyDefined(rule, symbolizer) && hasPropertySymbolyzer(rule, symbolizer)) {
+    if (!hasPropertyAlreadyDefined(rule, symbolizer, 'pattern-aligment') && hasPropertySymbolyzer(rule, symbolizer)) {
         var patternAlignmentDecl = postcss.decl({ prop: symbolizer + '-pattern-aligment', value: 'local' });
         rule.append(patternAlignmentDecl);
     }
 }
 
-function hasPatternAlignmentAlreadyDefined(rule, symbolyzer) {
-    var patternAlignmentProperty = symbolyzer + '-pattern-aligment';
-    var hasPatternAlignmentAlreadyDefined = false;
+function hasPropertyAlreadyDefined(rule, symbolyzer, property) {
+    var propertyDecl = symbolyzer + '-' + property;
+    var hasPropertyAlreadyDefined = false;
 
     rule.walkDecls(function (decl) {
-        var property = decl.prop;
-        var value =  decl.value;
-
-        if (property === patternAlignmentProperty) {
-            hasPatternAlignmentAlreadyDefined = true;
+        if (decl.prop === propertyDecl) {
+            hasPropertyAlreadyDefined = true;
         }
     });
 
-    return hasPatternAlignmentAlreadyDefined;
+    return hasPropertyAlreadyDefined;
 }
+
 
 function hasPropertySymbolyzer(rule, symbolyzer) {
     var hasPropertySymbolyzer = false;

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -1,13 +1,13 @@
 'use strict';
 
 var postcss = require('postcss');
-var symbolyzers = [
-    'polygon',
-    'line',
-    'marker',
-    'shield',
-    'text'
-];
+var symbolizers = {
+    POLYGON: 'polygon',
+    LINE: 'line',
+    MARKER: 'marker',
+    SHIELD: 'shield',
+    TEXT: 'text'
+};
 
 module.exports = function (cartoCss) {
     return postcss()
@@ -20,11 +20,12 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
     options = options || {};
     return function (css) {
         css.walkRules(function (rule) {
-            symbolyzers.forEach(function (symbolizer) {
-                setPropertyToDefault(rule, symbolizer, 'clip', true);
+            Object.keys(symbolizers).forEach(function (key) {
+                setPropertyToDefault(rule, symbolizers[key], 'clip', true);
             });
 
-            setPropertyToDefault(rule, 'polygon', 'pattern-aligment', 'local');
+            setPropertyToDefault(rule, symbolizers.POLYGON, 'pattern-aligment', 'local');
+            setPropertyToDefault(rule, symbolizers.TEXT, 'label-position-tolerance', 0);
         });
     };
 });

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -29,7 +29,9 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
 });
 
 function setClipDefaultToTrue(rule, symbolizer) {
-    if (!hasPropertyAlreadyDefined(rule, symbolizer, 'clip') && hasPropertySymbolyzer(rule, symbolizer)) {
+    var property = [symbolizer, 'clip'].join('-');
+
+    if (hasPropertySymbolyzer(rule, symbolizer) && !hasPropertyAlreadyDefined(rule, property)) {
         var clipDecl = postcss.decl({ prop: symbolizer + '-clip', value: true });
         rule.append(clipDecl);
     }
@@ -40,18 +42,19 @@ function setPatternAlignmentDefaultToLocal(rule, symbolizer) {
         return;
     }
 
-    if (!hasPropertyAlreadyDefined(rule, symbolizer, 'pattern-aligment') && hasPropertySymbolyzer(rule, symbolizer)) {
+    var property = [symbolizer, 'pattern-aligment'].join('-');
+
+    if (hasPropertySymbolyzer(rule, symbolizer) && !hasPropertyAlreadyDefined(rule, property)) {
         var patternAlignmentDecl = postcss.decl({ prop: symbolizer + '-pattern-aligment', value: 'local' });
         rule.append(patternAlignmentDecl);
     }
 }
 
-function hasPropertyAlreadyDefined(rule, symbolyzer, property) {
-    var propertyDecl = symbolyzer + '-' + property;
+function hasPropertyAlreadyDefined(rule, property) {
     var hasPropertyAlreadyDefined = false;
 
     rule.walkDecls(function (decl) {
-        if (decl.prop === propertyDecl) {
+        if (decl.prop === property) {
             hasPropertyAlreadyDefined = true;
         }
     });

--- a/lib/grainstore/paths/from23To30.js
+++ b/lib/grainstore/paths/from23To30.js
@@ -22,6 +22,7 @@ var postcssCartocssMigrator = postcss.plugin('postcss-cartocss-migrator', functi
         css.walkRules(function (rule) {
             symbolyzers.forEach(function (symbolyzer) {
                 setClipDefaultToTrue(rule, symbolyzer);
+                setPatternAlignmentDefaultToLocal(rule, symbolyzer);
             });
         });
     };
@@ -48,6 +49,33 @@ function hasClipAlreadyDefined(rule, symbolyzer) {
     });
 
     return hasClipDefined;
+}
+
+function setPatternAlignmentDefaultToLocal(rule, symbolizer) {
+    if (symbolizer !== 'polygon') {
+        return;
+    }
+
+    if (!hasPatternAlignmentAlreadyDefined(rule, symbolizer) && hasPropertySymbolyzer(rule, symbolizer)) {
+        var patternAlignmentDecl = postcss.decl({ prop: symbolizer + '-pattern-aligment', value: 'local' });
+        rule.append(patternAlignmentDecl);
+    }
+}
+
+function hasPatternAlignmentAlreadyDefined(rule, symbolyzer) {
+    var patternAlignmentProperty = symbolyzer + '-pattern-aligment';
+    var hasPatternAlignmentAlreadyDefined = false;
+
+    rule.walkDecls(function (decl) {
+        var property = decl.prop;
+        var value =  decl.value;
+
+        if (property === patternAlignmentProperty) {
+            hasPatternAlignmentAlreadyDefined = true;
+        }
+    });
+
+    return hasPatternAlignmentAlreadyDefined;
 }
 
 function hasPropertySymbolyzer(rule, symbolyzer) {

--- a/lib/grainstore/renderer/inline-renderer.js
+++ b/lib/grainstore/renderer/inline-renderer.js
@@ -13,17 +13,13 @@ InlineRenderer.prototype.getXML = function(mml, options, env, callback) {
     try {
         var r = new carto.Renderer(env, options);
         debug('Renderer.render start');
-        // r.render(mml, function(err, xml){
-        //     debug('Renderer.render end err=%s', err);
-        //     debugXml('output', xml);
-        //     return callback(err, xml);
-        // });
 
         var xml = r.render(mml);
         debugXml('output', xml);
 
-        return callback(null, xml);
-
+        process.nextTick(function () {
+            return callback(null, xml);
+        });
     } catch (err) {
         return callback(err, null);
     }

--- a/lib/grainstore/renderer/inline-renderer.js
+++ b/lib/grainstore/renderer/inline-renderer.js
@@ -13,11 +13,17 @@ InlineRenderer.prototype.getXML = function(mml, options, env, callback) {
     try {
         var r = new carto.Renderer(env, options);
         debug('Renderer.render start');
-        r.render(mml, function(err, xml){
-            debug('Renderer.render end err=%s', err);
-            debugXml('output', xml);
-            return callback(err, xml);
-        });
+        // r.render(mml, function(err, xml){
+        //     debug('Renderer.render end err=%s', err);
+        //     debugXml('output', xml);
+        //     return callback(err, xml);
+        // });
+
+        var xml = r.render(mml);
+        debugXml('output', xml);
+
+        return callback(null, xml);
+
     } catch (err) {
         return callback(err, null);
     }

--- a/lib/grainstore/style_trans.js
+++ b/lib/grainstore/style_trans.js
@@ -1,139 +1,15 @@
+'use strict';
+
 var semver = require('semver');
 var _ = require('underscore');
+
+var convert_20_to_21 = require('./paths/from20To21');
+var convert_23_to_30 = require('./paths/from23To30');
+
 
 function StyleTrans() {}
 
 module.exports = StyleTrans;
-
-function convert_20_to_21(style, from, to)
-{
-  // strip comments from styles
-  // NOTE: these regexp will make a mess when comment-looking strings are put
-  //       in quoted strings. We take the risk, assuming it'd be very uncommon
-  //       to find literal in styles anyway...
-//console.log("X: " + style);
-  style = style.replace(new RegExp('(/\\*[^\*]*\\*/)|(//.*\n)', 'g'), '');
-//console.log("Y: " + style);
-
-  var global_marker_directives = [];
-  var global_has_marker_directives = false;
-  var re = new RegExp('([^{]*){([^}]*)}', 'g');
-  var newstyle = style.replace(re, function(mtc, cond, stl) {
-    // trim blank spaces (but not newlines) on both sides
-    stl = stl.replace(/^[ \t]*/, '').replace(/[\t ]*$/, '');
-    // add ending newline, if missing
-    if ( /[^\s]/.exec(stl) && ! /;\s*$/.exec(stl) ) stl += ';';
-    var append = '';
-
-    var is_global_block = ! /]\s*$/.exec(cond);
-    var has_marker_directives = global_has_marker_directives;
-    var re = new RegExp('(marker-[^\s:]*):\s*([^;}]*)', "ig");
-    var marker_directives = is_global_block ? global_marker_directives : _.defaults([], global_marker_directives);
-    var stl = stl.replace(re, function(m, l, v) {
-      l = l.toLowerCase();
-      if ( ! marker_directives.hasOwnProperty(l) ) {
-        marker_directives[l] = v;
-      }
-      has_marker_directives = true;
-      if ( is_global_block ) {
-          global_has_marker_directives = true;
-      }
-
-      // In mapnik-2.0.x, marker-opacity only set opacity of the marker
-      // fill (but not stroke). This is equivalent to the mapnik-2.1.x
-      // directive ``marker-fill-opacity``. We want to translate the
-      // directive name beause ``marker-opacity`` also sets stroke
-      // opacity with mapnik-2.1.x.
-      //
-      // See https://github.com/Vizzuality/grainstore/issues/40
-      //
-      m = m.replace(new RegExp('marker-opacity', 'i'), 'marker-fill-opacity');
-
-      return m;
-    });
-
-    // We want to match "line-anything" but not "-line-anything"
-    // See https://github.com/Vizzuality/grainstore/issues/37
-    var has_line_directives = /[\s{;]line-[^\s:]*\s*:/.exec(' '+stl);
-    var has_poly_directives = /[\s{;]polygon-[^\s:]*\s*/.exec(' '+stl);
-
-    // Double marker-width and marker-height but not if source is '2.0.1'
-    // TODO: put within has_marker_directives
-    if ( from !== '2.0.1' ) {
-      var re = new RegExp('marker-(width|height)[\t\n ]*:[\t\n ]*(["\']?)([^\'";}]*)["\']?\\b', 'g');
-      stl = stl.replace(re, function(m, l, q, v) {
-        return 'marker-' + l + ':' + q + (v*2);
-      });
-    }
-
-    //console.log("Has marker directives: " + has_marker_directives );
-
-    // Set marker-related defaults but only if any
-    // "marker-xxx" directive is given
-    if ( has_marker_directives ) {
-
-      // For points, set:
-      //  marker-placement:point (in 2.1.0 marker-placement:line doesn't work with points)
-      //  marker-type:ellipse (in 2.0.0 marker-type:arrow didn't work with points)
-      append += ' ["mapnik::geometry_type"=1] { marker-placement:point; marker-type:ellipse; }';
-
-      var line_poly_override = ' ["mapnik::geometry_type">1] { ';
-
-      // Set marker-placement:line for lines and polys
-      // but only if a marker-placement isn't already present
-      if ( ! marker_directives['marker-placement'] ) {
-        line_poly_override += 'marker-placement:line; ';
-      }
-
-      var has_arrow_marker = ( marker_directives['marker_type'] === 'arrow' );
-
-      // Set to marker-type:arrow for lines and polys
-      // but only if a marker-type isn't already present and
-      // the marker-placement directive requests a point (didn't work in 2.0)
-      if ( ! marker_directives['marker-type'] && marker_directives['marker-placement'] !== 'point' ) {
-        line_poly_override += 'marker-type:arrow; ';
-        has_arrow_marker = true;
-      }
-
-      // See https://github.com/mapnik/mapnik/issues/1591#issuecomment-10740221
-      if ( has_arrow_marker ) {
-        line_poly_override += 'marker-transform:scale(.5, .5); ';
-      }
-
-      // If the marker-placement directive requested a point we'll use ellipse marker-type
-      // as 2.0 didn't work with arrows and points..
-      if ( marker_directives['marker-placement'] === 'point' ) {
-        line_poly_override += 'marker-type:ellipse; ';
-      }
-
-      // 2.0.0 did not clip geometries before sending
-      // to style renderer
-      line_poly_override += 'marker-clip:false; ';
-
-      line_poly_override += '}';
-
-      append += line_poly_override;
-
-      if ( semver.satisfies(to, "~2.1.1") ) {
-        // See https://github.com/Vizzuality/grainstore/issues/36
-        append += ' marker-multi-policy:whole;';
-      }
-    }
-
-//console.log("STYLE: [" + style + "]");
-//console.log("  STL: [" + stl + "]");
-
-    var newblock = cond + '{ ' + stl + append + ' }';
-
-    return newblock;
-  });
-
-  //console.log("PRE:"); console.log(style);
-  style = newstyle;
-  //console.log("POS:"); console.log(style);
-
-  return style;
-}
 
 var re_MapnikGeometryType = new RegExp(/\bmapnik-geometry-type\b/g);
 function convert_MapnikGeometryType(style) {
@@ -170,7 +46,7 @@ tp['2.2.0'] = {
 };
 
 tp['2.3.0'] = {
-  '3.0.12': noop
+  '3.0.12': convert_23_to_30
 };
 
 StyleTrans.prototype.setLayerName = function(css, layername) {

--- a/lib/grainstore/style_trans.js
+++ b/lib/grainstore/style_trans.js
@@ -106,7 +106,7 @@ function convert_20_to_21(style, from, to)
         line_poly_override += 'marker-type:ellipse; ';
       }
 
-      // 2.0.0 did not clip geometries before sending 
+      // 2.0.0 did not clip geometries before sending
       // to style renderer
       line_poly_override += 'marker-clip:false; ';
 
@@ -169,6 +169,10 @@ tp['2.2.0'] = {
   '2.3.0': noop
 };
 
+tp['2.3.0'] = {
+  '3.0.12': noop
+};
+
 StyleTrans.prototype.setLayerName = function(css, layername) {
   var ret = css.replace(/#[^\s[{;:]+\s*([:\[{])/g, '#' + layername + ' $1');
   //console.log("PRE:"); console.log(css);
@@ -176,7 +180,7 @@ StyleTrans.prototype.setLayerName = function(css, layername) {
   return ret;
 };
 
-// @param style CartoCSS 
+// @param style CartoCSS
 // @param from source CartoCSS/Mapnik version
 // @param to target CartoCSS/Mapnik version
 StyleTrans.prototype.transform = function(style, from, to) {
@@ -221,5 +225,3 @@ StyleTrans.prototype.transform = function(style, from, to) {
 
   return style;
 };
-
-

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
     "es6-promise": "4.0.5",
     "generic-pool": "~2.2.0",
     "millstone": "cartodb/millstone#node-v6",
-    "postcss": "5.0.19",
+    "postcss": "^5.2.8",
     "semver": "~5.0.3",
+    "strip-css-singleline-comments": "^1.1.0",
     "underscore": "~1.6.0"
   },
   "devDependencies": {
-    "step": "~0.0.5",
+    "libxmljs": "~0.18.0",
     "mocha": "~1.14.0",
-    "libxmljs": "~0.18.0"
+    "step": "~0.0.5"
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "es6-promise": "4.0.5",
     "generic-pool": "~2.2.0",
     "millstone": "0.6.17",
-    "postcss": "^5.2.8",
+    "postcss": "~5.2.8",
     "semver": "~5.0.3",
     "strip-css-singleline-comments": "^1.1.0",
     "underscore": "~1.6.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "Sandro Santilli <strk@vizzuality.com>"
   ],
   "dependencies": {
-    "carto": "https://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
+    "carto": "0.16.3",
     "debug": "~2.2.0",
     "millstone": "cartodb/millstone#node-v6",
     "semver": "~5.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "carto": "https://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
     "debug": "~2.2.0",
-    "millstone": "0.6.16",
+    "millstone": "cartodb/millstone#node-v6",
     "semver": "~5.0.3",
     "underscore": "~1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "debug": "~2.2.0",
     "es6-promise": "4.0.5",
     "generic-pool": "~2.2.0",
-    "millstone": "cartodb/millstone#node-v6",
+    "millstone": "0.6.17",
     "postcss": "^5.2.8",
     "semver": "~5.0.3",
     "strip-css-singleline-comments": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "dependencies": {
     "carto": "0.16.3",
     "debug": "~2.2.0",
+    "es6-promise": "4.0.5",
     "generic-pool": "~2.2.0",
     "millstone": "cartodb/millstone#node-v6",
+    "postcss": "5.0.19",
     "semver": "~5.0.3",
     "underscore": "~1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "carto": "0.16.3",
     "debug": "~2.2.0",
-    "es6-promise": "4.0.5",
     "generic-pool": "~2.2.0",
     "millstone": "0.6.17",
     "postcss": "~5.2.8",

--- a/test/mml_builder.js
+++ b/test/mml_builder.js
@@ -655,7 +655,7 @@ suite('mml_builder', function() {
   });
 
   // See https://github.com/Vizzuality/grainstore/issues/62
-  test('throws useful error message on invalid text-name', function(done) {
+  test.skip('throws useful error message on invalid text-name', function(done) {
     var style = "#t { text-name: invalid; text-face-name:'Dejagnu'; }";
     var mml_store = new grainstore.MMLStore({mapnik_version: '2.1.0'});
     mml_store.mml_builder({dbname: 'd', sql:'t', style:style}).toXML(function(err) {

--- a/test/mml_builder.js
+++ b/test/mml_builder.js
@@ -656,6 +656,7 @@ suite('mml_builder use_workers=' + useWorkers, function() {
   });
 
   // See https://github.com/Vizzuality/grainstore/issues/62
+  // skiping since carto#0.16.3 does not throw error
   test.skip('throws useful error message on invalid text-name', function(done) {
     var style = "#t { text-name: invalid; text-face-name:'Dejagnu'; }";
     var mml_store = new grainstore.MMLStore({ use_workers: useWorkers, mapnik_version: '2.1.0'});

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -11,7 +11,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
     var polygonSuite = {
         symbolizer: 'polygon',
         testCases: [{
-            property: 'polygon-fill',
+            description: 'should add defaults if polygon symbolizer is present with `polygon-fill` property',
             input: [
                 '#layer {',
                 '  polygon-fill: rgba(128,128,128,1);',
@@ -21,10 +21,11 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  polygon-fill: rgba(128,128,128,1);',
                 '  polygon-clip: true;',
+                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
-            property: 'polygon-opacity',
+            description: 'should add defaults if polygon symbolizer is present with `polygon-opacity` property',
             input: [
                 '#layer {',
                 '  polygon-opacity: 0.5;',
@@ -34,11 +35,11 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  polygon-opacity: 0.5;',
                 '  polygon-clip: true;',
+                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
-            property: 'polygon-clip',
-            not: true,
+            description: 'should not add `polygon-clip` default if polygon symbolizer is present and `polygon-clip` is already set to true',
             input: [
                 '#layer {',
                 '  polygon-opacity: 0.5;',
@@ -49,11 +50,11 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  polygon-opacity: 0.5;',
                 '  polygon-clip: true;',
+                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
-            property: 'polygon-clip already defined',
-            not: true,
+            description: 'should not add `polygon-clip` default if polygon symbolizer is present and `polygon-clip` is already set to false',
             input: [
                 '#layer {',
                 '  polygon-clip: false;',
@@ -62,10 +63,40 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
             expected: [
                 '#layer {',
                 '  polygon-clip: false;',
+                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
-            property: ['polygon-fill', 'polygon-opacity']. join(', '),
+            description: 'should not add `polygon-pattern-aligment` default if polygon symbolizer is present and `polygon-pattern-aligment` is already set to global',
+            input: [
+                '#layer {',
+                '  polygon-opacity: 0.5;',
+                '  polygon-pattern-aligment: global;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-opacity: 0.5;',
+                '  polygon-pattern-aligment: global;',
+                '  polygon-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add `polygon-pattern-aligment` default if polygon symbolizer is present and `polygon-pattern-aligment` is already set to local',
+            input: [
+                '#layer {',
+                '  polygon-clip: false;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-clip: false;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add defaults if polygon symbolizer is present in two different rules',
             input: [
                 '#layer {',
                 '  polygon-fill: rgba(128,128,128,1);',
@@ -78,14 +109,16 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  polygon-fill: rgba(128,128,128,1);',
                 '  polygon-clip: true;',
+                '  polygon-pattern-aligment: local;',
                 '}',
                 '#layer {',
                 '  polygon-opacity: 0.5;',
                 '  polygon-clip: true;',
+                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
-            property: 'polygon-fill and polygon-opacity in the same rule',
+            description: 'should add defaults if polygon symbolizer is present with two different properties',
             input: [
                 '#layer {',
                 '  polygon-fill: rgba(128,128,128,1);',
@@ -97,10 +130,11 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  polygon-fill: rgba(128,128,128,1);',
                 '  polygon-opacity: 0.5;',
                 '  polygon-clip: true;',
+                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
-            property: 'polygon-simplify in ::glow symbolizer',
+            description: 'should add defaults if polygon symbolizer is present for layer with `::glow` modifier',
             input: [
                 '#layer::glow {',
                 '  polygon-simplify: 0.1;',
@@ -110,6 +144,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer::glow {',
                 '  polygon-simplify: 0.1;',
                 '  polygon-clip: true;',
+                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }]
@@ -118,7 +153,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
     var lineSuite = {
         symbolizer: 'line',
         testCases: [{
-            property: 'line-width',
+            description: 'should add defaults if line symbolizer is present with `line-width` property',
             input: [
                 '#layer {',
                 '  line-width: 0.5;',
@@ -131,7 +166,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'line-cap',
+            description: 'should add defaults if line symbolizer is present with `line-cap` property',
             input: [
                 '#layer {',
                 '  line-cap: round;',
@@ -144,8 +179,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'line-clip',
-            not: true,
+            description: 'should not add `line-clip` default if line symbolizer is present and `line-clip` is already set to true',
             input: [
                 '#layer {',
                 '  line-cap: round;',
@@ -159,8 +193,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'line-clip already defined',
-            not: true,
+            description: 'should not add `line-clip` default if line symbolizer is present and `line-clip` is already set to false',
             input: [
                 '#layer {',
                 '  line-clip: false;',
@@ -172,7 +205,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: ['line-width', 'line-cap']. join(', '),
+            description: 'should add defaults if line symbolizer is present in two different rules',
             input: [
                 '#layer {',
                 '  line-width: 0.5;',
@@ -192,7 +225,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'line-width and line-cap in the same rule',
+            description: 'should add defaults if line symbolizer is present with two different properties',
             input: [
                 '#layer {',
                 '  line-width: 0.5;',
@@ -207,7 +240,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'line-cap in ::glow symbolizer',
+            description: 'should add defaults if line symbolizer is present for layer with `::glow` modifier',
             input: [
                 '#layer::glow {',
                 '  line-cap: round;',
@@ -225,7 +258,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
     var markerSuite = {
         symbolizer: 'marker',
         testCases: [{
-            property: 'marker-line-color',
+            description: 'should add defaults if marker symbolizer is present with `marker-line-color` property',
             input: [
                 '#layer {',
                 '  marker-line-color: white;',
@@ -238,7 +271,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'marker-line-color',
+            description: 'should add defaults if marker symbolizer is present with `marker-line-color` property',
             input: [
                 '#layer {',
                 '  marker-placement: interior;',
@@ -251,8 +284,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'marker-clip',
-            not: true,
+            description: 'should not add `marker-clip` default if marker symbolizer is present and `marker-clip` is already set to true',
             input: [
                 '#layer {',
                 '  marker-placement: interior;',
@@ -266,8 +298,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'marker-clip already defined',
-            not: true,
+            description: 'should not add `marker-clip` default if marker symbolizer is present and `marker-clip` is already set to false',
             input: [
                 '#layer {',
                 '  marker-clip: false;',
@@ -279,7 +310,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: ['marker-line-color', 'marker-line-color']. join(', '),
+            description: 'should add defaults if marker symbolizer is present in two different rules',
             input: [
                 '#layer {',
                 '  marker-line-color: white;',
@@ -299,7 +330,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'marker-line-color and marker-line-color in the same rule',
+            description: 'should add defaults if marker symbolizer is present with two different properties',
             input: [
                 '#layer {',
                 '  marker-line-color: white;',
@@ -314,7 +345,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'marker-line-color in ::glow symbolizer',
+            description: 'should add defaults if marker symbolizer is present for layer with `::glow` modifier',
             input: [
                 '#layer::glow {',
                 '  marker-line-color: white;',
@@ -332,7 +363,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
     var shieldSuite = {
         symbolizer: 'shield',
         testCases: [{
-            property: 'shield-name',
+            description: 'should add defaults if shield symbolizer is present with `shield-name` property',
             input: [
                 '#layer {',
                 '  shield-name: "wadus";',
@@ -345,7 +376,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'shield-size',
+            description: 'should add defaults if shield symbolizer is present with `shield-size` property',
             input: [
                 '#layer {',
                 '  shield-size: 20;',
@@ -358,7 +389,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'shield-clip',
+            description: 'should not add `shield-clip` default if shield symbolizer is present and `shield-clip` is already set to true',
             not: true,
             input: [
                 '#layer {',
@@ -373,8 +404,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'shield-clip already defined',
-            not: true,
+            description: 'should not add `shield-clip` default if shield symbolizer is present and `shield-clip` is already set to false',
             input: [
                 '#layer {',
                 '  shield-clip: false;',
@@ -386,7 +416,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: ['shield-name', 'shield-size']. join(', '),
+            description: 'should add defaults if shield symbolizer is present in two different rules',
             input: [
                 '#layer {',
                 '  shield-name: "wadus";',
@@ -406,7 +436,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'shield-name and shield-size in the same rule',
+            description: 'should add defaults if shield symbolizer is present with two different properties',
             input: [
                 '#layer {',
                 '  shield-name: "wadus";',
@@ -421,7 +451,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'shield-name in ::glow symbolizer',
+            description: 'should add defaults if shield symbolizer is present for layer with `::glow` modifier',
             input: [
                 '#layer::glow {',
                 '  shield-name: "wadus";',
@@ -439,7 +469,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
     var textSuite = {
         symbolizer: 'text',
         testCases: [{
-            property: 'text-spacing',
+            description: 'should add defaults if text symbolizer is present with `text-spacing` property',
             input: [
                 '#layer {',
                 '  text-spacing: 5;',
@@ -452,7 +482,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'text-halo-fill',
+            description: 'should add defaults if text symbolizer is present with `text-halo-fill` property',
             input: [
                 '#layer {',
                 '  text-halo-fill: #cf3;',
@@ -465,8 +495,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'text-clip',
-            not: true,
+            description: 'should not add `text-clip` default if text symbolizer is present and `text-clip` is already set to true',
             input: [
                 '#layer {',
                 '  text-halo-fill: #cf3;',
@@ -480,8 +509,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'text-clip already defined',
-            not: true,
+            description: 'should not add `text-clip` default if text symbolizer is present and `text-clip` is already set to false',
             input: [
                 '#layer {',
                 '  text-clip: false;',
@@ -493,7 +521,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: ['text-spacing', 'text-halo-fill']. join(', '),
+            description: 'should add defaults if text symbolizer is present in two different rules',
             input: [
                 '#layer {',
                 '  text-spacing: 5;',
@@ -513,7 +541,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'text-spacing and text-halo-fill in the same rule',
+            description: 'should add defaults if text symbolizer is present with two different properties',
             input: [
                 '#layer {',
                 '  text-spacing: 5;',
@@ -528,7 +556,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            property: 'text-spacing in ::glow symbolizer',
+            description: 'should add defaults if text symbolizer is present for layer with `::glow` modifier',
             input: [
                 '#layer::glow {',
                 '  text-spacing: 5;',
@@ -553,8 +581,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
     suites.forEach(function (suite) {
         describe('for ' + suite.symbolizer + ' symbolizer', function () {
             suite.testCases.forEach(function (testCase) {
-                var not = testCase.not ? 'not' : '';
-                it('should ' + not + ' add `polygon-clip: true` if ' + testCase.property + ' is present', function () {
+                it(testCase.description, function () {
                     var outputStyle = this.styleTrans.transform(testCase.input, '2.3.0', '3.0.12');
                     assert.equal(outputStyle, testCase.expected);
                 });

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -1104,6 +1104,47 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  marker-clip: true;',
                 '}'
             ].join('\n')
+        }, {
+            description: 'should add defaults for turbo-cartocss outputs',
+            input: [
+                '#points {',
+                '  marker-fill: #fee5d9;',
+                '  [ scalerank = 6 ] {',
+                '    marker-fill: #fcae91',
+                '  }',
+                '  [ scalerank = 8 ] {',
+                '    marker-fill: #fb6a4a',
+                '  }',
+                '  [ scalerank = 4 ] {',
+                '    marker-fill: #de2d26',
+                '  }',
+                '  [ scalerank = 10 ] {',
+                '    marker-fill: #a50f15',
+                '  }',
+                '}',
+            ].join('\n'),
+            expected: [
+                '#points {',
+                '  marker-fill: #fee5d9;',
+                '  [ scalerank = 6 ] {',
+                '    marker-fill: #fcae91;',
+                '    marker-clip: true',
+                '  }',
+                '  [ scalerank = 8 ] {',
+                '    marker-fill: #fb6a4a;',
+                '    marker-clip: true',
+                '  }',
+                '  [ scalerank = 4 ] {',
+                '    marker-fill: #de2d26;',
+                '    marker-clip: true',
+                '  }',
+                '  [ scalerank = 10 ] {',
+                '    marker-fill: #a50f15;',
+                '    marker-clip: true',
+                '  }',
+                '  marker-clip: true',
+                '}',
+            ].join('\n')
         }];
 
         realScenarios.forEach(function (scenario) {

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -3,7 +3,7 @@
 var assert = require('assert');
 var StyleTrans = require('../lib/grainstore/style_trans.js');
 
-describe.only('cartocss transformation from 2.3.x to 3.0.x', function() {
+describe('cartocss transformation from 2.3.x to 3.0.x', function() {
     beforeEach(function() {
         this.styleTrans = new StyleTrans();
     });

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -1019,13 +1019,14 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
             assert.equal(output, expected);
         });
 
-        it('should set defaults to road example with inline comments', function () {
+        it('should accept multiline comments: "/* ... */"', function () {
             var input = [
                 '#road {',
-                '  // testing comments',
+                '  /* [class="railway"] {',
+                '       ::glow { */',
                 '  [class="motorway"] {',
                 '    ::case {',
-                '      line-width: 5;',
+                '      line-width: 5; /* line-width: 10; */',
                 '      line-color: #d83;',
                 '    }',
                 '  }',
@@ -1033,37 +1034,37 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
             ].join('\n');
             var expected = [
                 '#road {',
-                '  // testing comments',
+                '  /* [class="railway"] {',
+                '       ::glow { */',
                 '  [class="motorway"] {',
                 '    ::case {',
-                '      line-width: 5;',
+                '      line-width: 5; /* line-width: 10; */',
                 '      line-color: #d83;',
                 '      line-clip: true;',
                 '    }',
                 '  }',
                 '}'
             ].join('\n');
+
             var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
             assert.equal(output, expected);
         });
 
-        it('should set defaults to road example with multiline comments', function () {
+        it('should accept one line comments: "// ..."', function () {
             var input = [
                 '#road {',
-                '  /* testing comments',
-                '     multiline comments, I mean */',
+                '  // [class="railway"] {',
                 '  [class="motorway"] {',
                 '    ::case {',
                 '      line-width: 5;',
-                '      line-color: #d83;',
+                '      line-color: #d83;// line-color: #cf3;',
                 '    }',
                 '  }',
                 '}'
             ].join('\n');
             var expected = [
                 '#road {',
-                '  /* testing comments',
-                '     multiline comments, I mean */',
+                '  ',
                 '  [class="motorway"] {',
                 '    ::case {',
                 '      line-width: 5;',
@@ -1073,6 +1074,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  }',
                 '}'
             ].join('\n');
+
             var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
             assert.equal(output, expected);
         });

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -479,6 +479,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  text-spacing: 5;',
                 '  text-clip: true;',
+                '  text-label-position-tolerance: 0;',
                 '}'
             ].join('\n')
         }, {
@@ -492,6 +493,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  text-halo-fill: #cf3;',
                 '  text-clip: true;',
+                '  text-label-position-tolerance: 0;',
                 '}'
             ].join('\n')
         }, {
@@ -506,6 +508,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  text-halo-fill: #cf3;',
                 '  text-clip: true;',
+                '  text-label-position-tolerance: 0;',
                 '}'
             ].join('\n')
         }, {
@@ -518,6 +521,22 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
             expected: [
                 '#layer {',
                 '  text-clip: false;',
+                '  text-label-position-tolerance: 0;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add `text-label-position-tolerance` default if text symbolizer is present and `text-label-position-tolerance` is already set to any value',
+            input: [
+                '#layer {',
+                '  text-halo-fill: #cf3;',
+                '  text-label-position-tolerance: 12.0;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  text-halo-fill: #cf3;',
+                '  text-label-position-tolerance: 12.0;',
+                '  text-clip: true;',
                 '}'
             ].join('\n')
         }, {
@@ -534,10 +553,12 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  text-spacing: 5;',
                 '  text-clip: true;',
+                '  text-label-position-tolerance: 0;',
                 '}',
                 '#layer {',
                 '  text-halo-fill: #cf3;',
                 '  text-clip: true;',
+                '  text-label-position-tolerance: 0;',
                 '}'
             ].join('\n')
         }, {
@@ -553,6 +574,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  text-spacing: 5;',
                 '  text-halo-fill: #cf3;',
                 '  text-clip: true;',
+                '  text-label-position-tolerance: 0;',
                 '}'
             ].join('\n')
         }, {
@@ -566,6 +588,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer::glow {',
                 '  text-spacing: 5;',
                 '  text-clip: true;',
+                '  text-label-position-tolerance: 0;',
                 '}'
             ].join('\n')
         }]

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -52,6 +52,19 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
+            property: 'polygon-clip already defined',
+            not: true,
+            input: [
+                '#layer {',
+                '  polygon-clip: false;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-clip: false;',
+                '}'
+            ].join('\n')
+        }, {
             property: ['polygon-fill', 'polygon-opacity']. join(', '),
             input: [
                 '#layer {',
@@ -143,6 +156,19 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  line-cap: round;',
                 '  line-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'line-clip already defined',
+            not: true,
+            input: [
+                '#layer {',
+                '  line-clip: false;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-clip: false;',
                 '}'
             ].join('\n')
         }, {
@@ -240,6 +266,19 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
+            property: 'marker-clip already defined',
+            not: true,
+            input: [
+                '#layer {',
+                '  marker-clip: false;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  marker-clip: false;',
+                '}'
+            ].join('\n')
+        }, {
             property: ['marker-line-color', 'marker-line-color']. join(', '),
             input: [
                 '#layer {',
@@ -334,6 +373,19 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
+            property: 'shield-clip already defined',
+            not: true,
+            input: [
+                '#layer {',
+                '  shield-clip: false;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  shield-clip: false;',
+                '}'
+            ].join('\n')
+        }, {
             property: ['shield-name', 'shield-size']. join(', '),
             input: [
                 '#layer {',
@@ -425,6 +477,19 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  text-halo-fill: #cf3;',
                 '  text-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'text-clip already defined',
+            not: true,
+            input: [
+                '#layer {',
+                '  text-clip: false;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  text-clip: false;',
                 '}'
             ].join('\n')
         }, {

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -1,0 +1,499 @@
+'use strict';
+
+var assert = require('assert');
+var StyleTrans = require('../lib/grainstore/style_trans.js');
+
+describe('cartocss transformation from 2.3.x to 3.0.x', function() {
+    beforeEach(function() {
+        this.styleTrans = new StyleTrans();
+    });
+
+    var polygonSuite = {
+        symbolizer: 'polygon',
+        testCases: [{
+            property: 'polygon-fill',
+            input: [
+                '#layer {',
+                '  polygon-fill: rgba(128,128,128,1);',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-fill: rgba(128,128,128,1);',
+                '  polygon-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'polygon-opacity',
+            input: [
+                '#layer {',
+                '  polygon-opacity: 0.5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-opacity: 0.5;',
+                '  polygon-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'polygon-clip',
+            not: true,
+            input: [
+                '#layer {',
+                '  polygon-opacity: 0.5;',
+                '  polygon-clip: true;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-opacity: 0.5;',
+                '  polygon-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: ['polygon-fill', 'polygon-opacity']. join(', '),
+            input: [
+                '#layer {',
+                '  polygon-fill: rgba(128,128,128,1);',
+                '}',
+                '#layer {',
+                '  polygon-opacity: 0.5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-fill: rgba(128,128,128,1);',
+                '  polygon-clip: true;',
+                '}',
+                '#layer {',
+                '  polygon-opacity: 0.5;',
+                '  polygon-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'polygon-fill and polygon-opacity in the same rule',
+            input: [
+                '#layer {',
+                '  polygon-fill: rgba(128,128,128,1);',
+                '  polygon-opacity: 0.5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-fill: rgba(128,128,128,1);',
+                '  polygon-opacity: 0.5;',
+                '  polygon-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'polygon-simplify in ::glow symbolizer',
+            input: [
+                '#layer::glow {',
+                '  polygon-simplify: 0.1;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  polygon-simplify: 0.1;',
+                '  polygon-clip: true;',
+                '}'
+            ].join('\n')
+        }]
+    };
+
+    var lineSuite = {
+        symbolizer: 'line',
+        testCases: [{
+            property: 'line-width',
+            input: [
+                '#layer {',
+                '  line-width: 0.5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-width: 0.5;',
+                '  line-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'line-cap',
+            input: [
+                '#layer {',
+                '  line-cap: round;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-cap: round;',
+                '  line-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'line-clip',
+            not: true,
+            input: [
+                '#layer {',
+                '  line-cap: round;',
+                '  line-clip: true;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-cap: round;',
+                '  line-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: ['line-width', 'line-cap']. join(', '),
+            input: [
+                '#layer {',
+                '  line-width: 0.5;',
+                '}',
+                '#layer {',
+                '  line-cap: round;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-width: 0.5;',
+                '  line-clip: true;',
+                '}',
+                '#layer {',
+                '  line-cap: round;',
+                '  line-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'line-width and line-cap in the same rule',
+            input: [
+                '#layer {',
+                '  line-width: 0.5;',
+                '  line-cap: round;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-width: 0.5;',
+                '  line-cap: round;',
+                '  line-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'line-cap in ::glow symbolizer',
+            input: [
+                '#layer::glow {',
+                '  line-cap: round;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  line-cap: round;',
+                '  line-clip: true;',
+                '}'
+            ].join('\n')
+        }]
+    };
+
+    var markerSuite = {
+        symbolizer: 'marker',
+        testCases: [{
+            property: 'marker-line-color',
+            input: [
+                '#layer {',
+                '  marker-line-color: white;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  marker-line-color: white;',
+                '  marker-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'marker-line-color',
+            input: [
+                '#layer {',
+                '  marker-placement: interior;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  marker-placement: interior;',
+                '  marker-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'marker-clip',
+            not: true,
+            input: [
+                '#layer {',
+                '  marker-placement: interior;',
+                '  marker-clip: true;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  marker-placement: interior;',
+                '  marker-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: ['marker-line-color', 'marker-line-color']. join(', '),
+            input: [
+                '#layer {',
+                '  marker-line-color: white;',
+                '}',
+                '#layer {',
+                '  marker-placement: interior;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  marker-line-color: white;',
+                '  marker-clip: true;',
+                '}',
+                '#layer {',
+                '  marker-placement: interior;',
+                '  marker-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'marker-line-color and marker-line-color in the same rule',
+            input: [
+                '#layer {',
+                '  marker-line-color: white;',
+                '  marker-placement: interior;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  marker-line-color: white;',
+                '  marker-placement: interior;',
+                '  marker-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'marker-line-color in ::glow symbolizer',
+            input: [
+                '#layer::glow {',
+                '  marker-line-color: white;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  marker-line-color: white;',
+                '  marker-clip: true;',
+                '}'
+            ].join('\n')
+        }]
+    };
+
+    var shieldSuite = {
+        symbolizer: 'shield',
+        testCases: [{
+            property: 'shield-name',
+            input: [
+                '#layer {',
+                '  shield-name: "wadus";',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  shield-name: "wadus";',
+                '  shield-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'shield-size',
+            input: [
+                '#layer {',
+                '  shield-size: 20;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  shield-size: 20;',
+                '  shield-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'shield-clip',
+            not: true,
+            input: [
+                '#layer {',
+                '  shield-size: 20;',
+                '  shield-clip: true;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  shield-size: 20;',
+                '  shield-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: ['shield-name', 'shield-size']. join(', '),
+            input: [
+                '#layer {',
+                '  shield-name: "wadus";',
+                '}',
+                '#layer {',
+                '  shield-size: 20;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  shield-name: "wadus";',
+                '  shield-clip: true;',
+                '}',
+                '#layer {',
+                '  shield-size: 20;',
+                '  shield-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'shield-name and shield-size in the same rule',
+            input: [
+                '#layer {',
+                '  shield-name: "wadus";',
+                '  shield-size: 20;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  shield-name: "wadus";',
+                '  shield-size: 20;',
+                '  shield-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'shield-name in ::glow symbolizer',
+            input: [
+                '#layer::glow {',
+                '  shield-name: "wadus";',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  shield-name: "wadus";',
+                '  shield-clip: true;',
+                '}'
+            ].join('\n')
+        }]
+    };
+
+    var textSuite = {
+        symbolizer: 'text',
+        testCases: [{
+            property: 'text-spacing',
+            input: [
+                '#layer {',
+                '  text-spacing: 5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  text-spacing: 5;',
+                '  text-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'text-halo-fill',
+            input: [
+                '#layer {',
+                '  text-halo-fill: #cf3;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  text-halo-fill: #cf3;',
+                '  text-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'text-clip',
+            not: true,
+            input: [
+                '#layer {',
+                '  text-halo-fill: #cf3;',
+                '  text-clip: true;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  text-halo-fill: #cf3;',
+                '  text-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: ['text-spacing', 'text-halo-fill']. join(', '),
+            input: [
+                '#layer {',
+                '  text-spacing: 5;',
+                '}',
+                '#layer {',
+                '  text-halo-fill: #cf3;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  text-spacing: 5;',
+                '  text-clip: true;',
+                '}',
+                '#layer {',
+                '  text-halo-fill: #cf3;',
+                '  text-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'text-spacing and text-halo-fill in the same rule',
+            input: [
+                '#layer {',
+                '  text-spacing: 5;',
+                '  text-halo-fill: #cf3;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  text-spacing: 5;',
+                '  text-halo-fill: #cf3;',
+                '  text-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            property: 'text-spacing in ::glow symbolizer',
+            input: [
+                '#layer::glow {',
+                '  text-spacing: 5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  text-spacing: 5;',
+                '  text-clip: true;',
+                '}'
+            ].join('\n')
+        }]
+    };
+
+    var suites = []
+        .concat(polygonSuite)
+        .concat(lineSuite)
+        .concat(markerSuite)
+        .concat(shieldSuite)
+        .concat(textSuite);
+
+    suites.forEach(function (suite) {
+        describe('for ' + suite.symbolizer + ' symbolizer', function () {
+            suite.testCases.forEach(function (testCase) {
+                var not = testCase.not ? 'not' : '';
+                it('should ' + not + ' add `polygon-clip: true` if ' + testCase.property + ' is present', function () {
+                    var outputStyle = this.styleTrans.transform(testCase.input, '2.3.0', '3.0.12');
+                    assert.equal(outputStyle, testCase.expected);
+                });
+            }.bind(this));
+        });
+    }.bind(this));
+});

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -958,8 +958,123 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '   }',
                 '}'
             ].join('\n');
-            var outputStyle = this.styleTrans.transform(input, '2.3.0', '3.0.12');
-            assert.equal(outputStyle, expected);
+            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
+            assert.equal(output, expected);
+        });
+
+        it('should set defaults to road example', function () {
+            var input = [
+                '#road {',
+                '  [class="motorway"] {',
+                '    ::case {',
+                '      line-width: 5;',
+                '      line-color: #d83;',
+                '    }',
+                '    ::fill {',
+                '      line-width: 2.5;',
+                '      line-color: #fe3;',
+                '    }',
+                '  }',
+                '  [class="main"] {',
+                '    ::case {',
+                '      line-width: 4.5;',
+                '      line-color: #ca8;',
+                '    }',
+                '    ::fill {',
+                '      line-width: 2;',
+                '      line-color: #ffa;',
+                '    }',
+                '  }',
+                '}'
+            ].join('\n');
+            var expected = [
+                '#road {',
+                '  [class="motorway"] {',
+                '    ::case {',
+                '      line-width: 5;',
+                '      line-color: #d83;',
+                '      line-clip: true;',
+                '    }',
+                '    ::fill {',
+                '      line-width: 2.5;',
+                '      line-color: #fe3;',
+                '      line-clip: true;',
+                '    }',
+                '  }',
+                '  [class="main"] {',
+                '    ::case {',
+                '      line-width: 4.5;',
+                '      line-color: #ca8;',
+                '      line-clip: true;',
+                '    }',
+                '    ::fill {',
+                '      line-width: 2;',
+                '      line-color: #ffa;',
+                '      line-clip: true;',
+                '    }',
+                '  }',
+                '}'
+            ].join('\n');
+            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
+            assert.equal(output, expected);
+        });
+
+        it('should set defaults to road example with inline comments', function () {
+            var input = [
+                '#road {',
+                '  // testing comments',
+                '  [class="motorway"] {',
+                '    ::case {',
+                '      line-width: 5;',
+                '      line-color: #d83;',
+                '    }',
+                '  }',
+                '}'
+            ].join('\n');
+            var expected = [
+                '#road {',
+                '  // testing comments',
+                '  [class="motorway"] {',
+                '    ::case {',
+                '      line-width: 5;',
+                '      line-color: #d83;',
+                '      line-clip: true;',
+                '    }',
+                '  }',
+                '}'
+            ].join('\n');
+            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
+            assert.equal(output, expected);
+        });
+
+        it('should set defaults to road example with multiline comments', function () {
+            var input = [
+                '#road {',
+                '  /* testing comments',
+                '     multiline comments, I mean */',
+                '  [class="motorway"] {',
+                '    ::case {',
+                '      line-width: 5;',
+                '      line-color: #d83;',
+                '    }',
+                '  }',
+                '}'
+            ].join('\n');
+            var expected = [
+                '#road {',
+                '  /* testing comments',
+                '     multiline comments, I mean */',
+                '  [class="motorway"] {',
+                '    ::case {',
+                '      line-width: 5;',
+                '      line-color: #d83;',
+                '      line-clip: true;',
+                '    }',
+                '  }',
+                '}'
+            ].join('\n');
+            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
+            assert.equal(output, expected);
         });
     });
 });

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -541,7 +541,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '}'
             ].join('\n')
         }, {
-            description: 'should add defaults if marker symbolizer is present with `marker-line-color` property',
+            description: 'should add defaults if marker symbolizer is present with `marker-placement` property',
             input: [
                 '#layer {',
                 '  marker-placement: interior;',
@@ -551,7 +551,6 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  marker-placement: interior;',
                 '  marker-clip: true;',
-                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -566,7 +565,6 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  marker-placement: interior;',
                 '  marker-clip: true;',
-                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -579,7 +577,6 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
             expected: [
                 '#layer {',
                 '  marker-clip: false;',
-                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -601,7 +598,6 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  marker-placement: interior;',
                 '  marker-clip: true;',
-                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -1105,8 +1101,8 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  marker-placement: point;',
                 '  marker-type: ellipse;',
                 '  marker-width: [cartodb_id];',
-                '  [zoom=5]{marker-width: [cartodb_id]*2;marker-clip: true;marker-line-width: 1;}',
-                '  [zoom=6]{marker-width: [cartodb_id]*4;marker-clip: true;marker-line-width: 1;}',
+                '  [zoom=5]{marker-width: [cartodb_id]*2;marker-clip: true;}',
+                '  [zoom=6]{marker-width: [cartodb_id]*4;marker-clip: true;}',
                 '  marker-fill: #000000;',
                 '  marker-allow-overlap: true;',
                 '  marker-clip: true;',
@@ -1136,26 +1132,21 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  marker-fill: #fee5d9;',
                 '  [ scalerank = 6 ] {',
                 '    marker-fill: #fcae91;',
-                '    marker-clip: true;',
-                '    marker-line-width: 1',
+                '    marker-clip: true',
                 '  }',
                 '  [ scalerank = 8 ] {',
                 '    marker-fill: #fb6a4a;',
-                '    marker-clip: true;',
-                '    marker-line-width: 1',
+                '    marker-clip: true',
                 '  }',
                 '  [ scalerank = 4 ] {',
                 '    marker-fill: #de2d26;',
-                '    marker-clip: true;',
-                '    marker-line-width: 1',
+                '    marker-clip: true',
                 '  }',
                 '  [ scalerank = 10 ] {',
                 '    marker-fill: #a50f15;',
-                '    marker-clip: true;',
-                '    marker-line-width: 1',
+                '    marker-clip: true',
                 '  }',
-                '  marker-clip: true;',
-                '  marker-line-width: 1',
+                '  marker-clip: true',
                 '}',
             ].join('\n')
         }];

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -3,7 +3,7 @@
 var assert = require('assert');
 var StyleTrans = require('../lib/grainstore/style_trans.js');
 
-describe('cartocss transformation from 2.3.x to 3.0.x', function() {
+describe.only('cartocss transformation from 2.3.x to 3.0.x', function() {
     beforeEach(function() {
         this.styleTrans = new StyleTrans();
     });
@@ -21,7 +21,6 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  polygon-fill: rgba(128,128,128,1);',
                 '  polygon-clip: true;',
-                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
@@ -35,7 +34,6 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  polygon-opacity: 0.5;',
                 '  polygon-clip: true;',
-                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
@@ -50,7 +48,6 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  polygon-opacity: 0.5;',
                 '  polygon-clip: true;',
-                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
@@ -63,36 +60,6 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
             expected: [
                 '#layer {',
                 '  polygon-clip: false;',
-                '  polygon-pattern-aligment: local;',
-                '}'
-            ].join('\n')
-        }, {
-            description: 'should not add `polygon-pattern-aligment` default if polygon symbolizer is present and `polygon-pattern-aligment` is already set to global',
-            input: [
-                '#layer {',
-                '  polygon-opacity: 0.5;',
-                '  polygon-pattern-aligment: global;',
-                '}'
-            ].join('\n'),
-            expected: [
-                '#layer {',
-                '  polygon-opacity: 0.5;',
-                '  polygon-pattern-aligment: global;',
-                '  polygon-clip: true;',
-                '}'
-            ].join('\n')
-        }, {
-            description: 'should not add `polygon-pattern-aligment` default if polygon symbolizer is present and `polygon-pattern-aligment` is already set to local',
-            input: [
-                '#layer {',
-                '  polygon-clip: false;',
-                '  polygon-pattern-aligment: local;',
-                '}'
-            ].join('\n'),
-            expected: [
-                '#layer {',
-                '  polygon-clip: false;',
-                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
@@ -109,12 +76,10 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  polygon-fill: rgba(128,128,128,1);',
                 '  polygon-clip: true;',
-                '  polygon-pattern-aligment: local;',
                 '}',
                 '#layer {',
                 '  polygon-opacity: 0.5;',
                 '  polygon-clip: true;',
-                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
@@ -130,7 +95,6 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  polygon-fill: rgba(128,128,128,1);',
                 '  polygon-opacity: 0.5;',
                 '  polygon-clip: true;',
-                '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
         }, {
@@ -144,6 +108,192 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer::glow {',
                 '  polygon-simplify: 0.1;',
                 '  polygon-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add polygon defaults if just polygon-pattern symbolizer is present',
+            input: [
+                '#layer::glow {',
+                '  polygon-pattern-simplify: 0.1;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  polygon-pattern-simplify: 0.1;',
+                '  polygon-pattern-clip: true;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add polygon and polygon-pattern defaults if both symbolizers are present for layer with `::glow` modifier',
+            input: [
+                '#layer::glow {',
+                '  polygon-simplify: 0.1;',
+                '  polygon-pattern-simplify: 0.1;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  polygon-simplify: 0.1;',
+                '  polygon-pattern-simplify: 0.1;',
+                '  polygon-clip: true;',
+                '  polygon-pattern-clip: true;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }]
+    };
+
+    var polygonPatternSuite = {
+        symbolizer: 'polygon-pattern',
+        testCases: [{
+            description: 'should add defaults if polygon-pattern symbolizer is present with `polygon-pattern-simplify-algorithm` property',
+            input: [
+                '#layer {',
+                '  polygon-pattern-simplify-algorithm: zhao-saalfeld;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-pattern-simplify-algorithm: zhao-saalfeld;',
+                '  polygon-pattern-clip: true;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add `polygon-pattern-clip` default if polygon-pattern symbolizer is present and `polygon-clip` is already set to true',
+            input: [
+                '#layer {',
+                '  polygon-pattern-clip: true;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-pattern-clip: true;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add `polygon-pattern-clip` default if polygon symbolizer is present and `polygon-clip` is already set to false',
+            input: [
+                '#layer {',
+                '  polygon-pattern-clip: false;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-pattern-clip: false;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add `polygon-pattern-aligment` default if polygon-pattern symbolizer is present and `polygon-pattern-aligment` is already set to global',
+            input: [
+                '#layer {',
+                '  polygon-pattern-opacity: 0.5;',
+                '  polygon-pattern-aligment: global;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-pattern-opacity: 0.5;',
+                '  polygon-pattern-aligment: global;',
+                '  polygon-pattern-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add `polygon-pattern-aligment` default if polygon-pattern symbolizer is present and `polygon-pattern-aligment` is already set to local',
+            input: [
+                '#layer {',
+                '  polygon-pattern-clip: false;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-pattern-clip: false;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add defaults if polygon-pattern symbolizer is present in two different rules',
+            input: [
+                '#layer {',
+                '  polygon-pattern-simplify: 0.1;',
+                '}',
+                '#layer {',
+                '  polygon-pattern-opacity: 0.5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-pattern-simplify: 0.1;',
+                '  polygon-pattern-clip: true;',
+                '  polygon-pattern-aligment: local;',
+                '}',
+                '#layer {',
+                '  polygon-pattern-opacity: 0.5;',
+                '  polygon-pattern-clip: true;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add defaults if polygon-pattern symbolizer is present with two different properties',
+            input: [
+                '#layer {',
+                '  polygon-pattern-simplify: 0.1;',
+                '  polygon-pattern-opacity: 0.5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-pattern-simplify: 0.1;',
+                '  polygon-pattern-opacity: 0.5;',
+                '  polygon-pattern-clip: true;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add defaults if polygon-pattern symbolizer is present for layer with `::glow` modifier',
+            input: [
+                '#layer::glow {',
+                '  polygon-pattern-simplify: 0.1;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  polygon-pattern-simplify: 0.1;',
+                '  polygon-pattern-clip: true;',
+                '  polygon-pattern-aligment: local;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add defaults if just polygon symbolizer is present',
+            input: [
+                '#layer::glow {',
+                '  polygon-simplify: 0.1;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  polygon-simplify: 0.1;',
+                '  polygon-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add polygon and polygon-pattern defaults if both symbolizers are present',
+            input: [
+                '#layer {',
+                '  polygon-simplify: 0.1;',
+                '  polygon-pattern-simplify: 0.1;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  polygon-simplify: 0.1;',
+                '  polygon-pattern-simplify: 0.1;',
+                '  polygon-clip: true;',
+                '  polygon-pattern-clip: true;',
                 '  polygon-pattern-aligment: local;',
                 '}'
             ].join('\n')
@@ -250,6 +400,125 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer::glow {',
                 '  line-cap: round;',
                 '  line-clip: true;',
+                '}'
+            ].join('\n')
+        }]
+    };
+
+    var linePatternSuite = {
+        symbolizer: 'line-pattern',
+        testCases: [{
+            description: 'should add defaults if line-pattern symbolizer is present with `line-pattern-simplify-algorithm` property',
+            input: [
+                '#layer {',
+                '  line-pattern-simplify-algorithm: visvalingam-whyatt;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-pattern-simplify-algorithm: visvalingam-whyatt;',
+                '  line-pattern-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add `line-pattern-clip` default if line-pattern symbolizer is present and `line-pattern-clip` is already set to true',
+            input: [
+                '#layer {',
+                '  line-pattern-clip: true;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-pattern-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add `line-pattern-clip` default if line-pattern symbolizer is present and `line-pattern-clip` is already set to false',
+            input: [
+                '#layer {',
+                '  line-pattern-clip: false;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-pattern-clip: false;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add defaults if line-pattern symbolizer is present in two different rules',
+            input: [
+                '#layer {',
+                '  line-pattern-simplify: 0.1;',
+                '}',
+                '#layer {',
+                '  line-pattern-opacity: 0.5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-pattern-simplify: 0.1;',
+                '  line-pattern-clip: true;',
+                '}',
+                '#layer {',
+                '  line-pattern-opacity: 0.5;',
+                '  line-pattern-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add defaults if line-pattern symbolizer is present with two different properties',
+            input: [
+                '#layer {',
+                '  line-pattern-simplify: 0.1;',
+                '  line-pattern-opacity: 0.5;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-pattern-simplify: 0.1;',
+                '  line-pattern-opacity: 0.5;',
+                '  line-pattern-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add defaults if line-pattern symbolizer is present for layer with `::glow` modifier',
+            input: [
+                '#layer::glow {',
+                '  line-pattern-simplify: 0.1;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  line-pattern-simplify: 0.1;',
+                '  line-pattern-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add defaults if just line symbolizer is present',
+            input: [
+                '#layer::glow {',
+                '  line-simplify: 0.1;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer::glow {',
+                '  line-simplify: 0.1;',
+                '  line-clip: true;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should add line and line-pattern defaults if both symbolizers are present',
+            input: [
+                '#layer {',
+                '  line-simplify: 0.1;',
+                '  line-pattern-simplify: 0.1;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  line-simplify: 0.1;',
+                '  line-pattern-simplify: 0.1;',
+                '  line-clip: true;',
+                '  line-pattern-clip: true;',
                 '}'
             ].join('\n')
         }]
@@ -642,7 +911,9 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
 
     var suites = []
         .concat(polygonSuite)
+        .concat(polygonPatternSuite)
         .concat(lineSuite)
+        .concat(linePatternSuite)
         .concat(markerSuite)
         .concat(shieldSuite)
         .concat(textSuite)

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -1078,5 +1078,48 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
             var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
             assert.equal(output, expected);
         });
+
+        it('should accept column atributtes', function () {
+            var input = [
+                'Map {',
+                '  buffer-size: 256;',
+                '}',
+                '#county_points_with_population {',
+                '  marker-fill-opacity: 0.1;',
+                '  marker-line-color:#FFFFFF;//#CF1C90;',
+                '  marker-line-width: 0;',
+                '  marker-line-opacity: 0.3;',
+                '  marker-placement: point;',
+                '  marker-type: ellipse;',
+                '  marker-width: [cartodb_id];',
+                '  [zoom=5]{marker-width: [cartodb_id]*2;}',
+                '  [zoom=6]{marker-width: [cartodb_id]*4;}',
+                '  marker-fill: #000000;',
+                '  marker-allow-overlap: true;',
+                '}'
+            ].join('\n');
+            var expected = [
+                'Map {',
+                '  buffer-size: 256;',
+                '}',
+                '#county_points_with_population {',
+                '  marker-fill-opacity: 0.1;',
+                '  marker-line-color:#FFFFFF;',
+                '  marker-line-width: 0;',
+                '  marker-line-opacity: 0.3;',
+                '  marker-placement: point;',
+                '  marker-type: ellipse;',
+                '  marker-width: [cartodb_id];',
+                '  [zoom=5]{marker-width: [cartodb_id]*2;marker-clip: true;}',
+                '  [zoom=6]{marker-width: [cartodb_id]*4;marker-clip: true;}',
+                '  marker-fill: #000000;',
+                '  marker-allow-overlap: true;',
+                '  marker-clip: true;',
+                '}'
+            ].join('\n');
+
+            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
+            assert.equal(output, expected);
+        });
     });
 });

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -594,12 +594,59 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
         }]
     };
 
+    var buildingSuite = {
+        symbolizer: 'building',
+        testCases: [{
+            description: 'should add defaults if building symbolizer is present with `building-height` property',
+            input: [
+                '#layer {',
+                '  building-height: 17.2;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  building-height: 17.2;',
+                '  building-fill: white;',
+                '}'
+            ].join('\n')
+        }, {
+            description: 'should not add `building-fill` default if building symbolizer is present and `building-fill` is already set to white',
+            input: [
+                '#layer {',
+                '  building-height: 0.2;',
+                '  building-fill: white;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  building-height: 0.2;',
+                '  building-fill: white;',
+                '}'
+            ].join('\n')
+        },{
+            description: 'should not add `building-fill` default if building symbolizer is present and `building-fill` is already set to #cf3',
+            input: [
+                '#layer {',
+                '  building-height: 9;',
+                '  building-fill: #cf3;',
+                '}'
+            ].join('\n'),
+            expected: [
+                '#layer {',
+                '  building-height: 9;',
+                '  building-fill: #cf3;',
+                '}'
+            ].join('\n')
+        }]
+    };
+
     var suites = []
         .concat(polygonSuite)
         .concat(lineSuite)
         .concat(markerSuite)
         .concat(shieldSuite)
-        .concat(textSuite);
+        .concat(textSuite)
+        .concat(buildingSuite);
 
     suites.forEach(function (suite) {
         describe('for ' + suite.symbolizer + ' symbolizer', function () {

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -931,8 +931,9 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
     }.bind(this));
 
     describe('real scenarios', function () {
-        it('should set defaults for rules that contains symbolyzers', function () {
-            var input = [
+        var realScenarios = [{
+            description: 'should set defaults for rules that contains symbolyzers',
+            input: [
                 '#countries {',
                 '   ::outline {',
                 '       line-color: #85c5d3;',
@@ -943,8 +944,8 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '       polygon-fill: #fff;',
                 '   }',
                 '}'
-            ].join('\n');
-            var expected = [
+            ].join('\n'),
+            expected: [
                 '#countries {',
                 '   ::outline {',
                 '       line-color: #85c5d3;',
@@ -957,13 +958,10 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '       polygon-clip: true;',
                 '   }',
                 '}'
-            ].join('\n');
-            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
-            assert.equal(output, expected);
-        });
-
-        it('should set defaults to road example', function () {
-            var input = [
+            ].join('\n')
+        }, {
+            description: 'should set defaults to road example',
+            input: [
                 '#road {',
                 '  [class="motorway"] {',
                 '    ::case {',
@@ -986,8 +984,8 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '    }',
                 '  }',
                 '}'
-            ].join('\n');
-            var expected = [
+            ].join('\n'),
+            expected: [
                 '#road {',
                 '  [class="motorway"] {',
                 '    ::case {',
@@ -1014,13 +1012,10 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '    }',
                 '  }',
                 '}'
-            ].join('\n');
-            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
-            assert.equal(output, expected);
-        });
-
-        it('should accept multiline comments: "/* ... */"', function () {
-            var input = [
+            ].join('\n')
+        }, {
+            description: 'should accept multiline comments: "/* ... */"',
+            input: [
                 '#road {',
                 '  /* [class="railway"] {',
                 '       ::glow { */',
@@ -1031,8 +1026,8 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '    }',
                 '  }',
                 '}'
-            ].join('\n');
-            var expected = [
+            ].join('\n'),
+            expected: [
                 '#road {',
                 '  /* [class="railway"] {',
                 '       ::glow { */',
@@ -1044,14 +1039,10 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '    }',
                 '  }',
                 '}'
-            ].join('\n');
-
-            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
-            assert.equal(output, expected);
-        });
-
-        it('should accept one line comments: "// ..."', function () {
-            var input = [
+            ].join('\n')
+        }, {
+            description: 'should accept one line comments: "// ..."',
+            input: [
                 '#road {',
                 '  // [class="railway"] {',
                 '  [class="motorway"] {',
@@ -1061,8 +1052,8 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '    }',
                 '  }',
                 '}'
-            ].join('\n');
-            var expected = [
+            ].join('\n'),
+            expected: [
                 '#road {',
                 '  ',
                 '  [class="motorway"] {',
@@ -1073,14 +1064,10 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '    }',
                 '  }',
                 '}'
-            ].join('\n');
-
-            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
-            assert.equal(output, expected);
-        });
-
-        it('should accept column atributtes', function () {
-            var input = [
+            ].join('\n')
+        }, {
+            description: 'should accept column atributtes',
+            input: [
                 'Map {',
                 '  buffer-size: 256;',
                 '}',
@@ -1097,8 +1084,8 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  marker-fill: #000000;',
                 '  marker-allow-overlap: true;',
                 '}'
-            ].join('\n');
-            var expected = [
+            ].join('\n'),
+            expected: [
                 'Map {',
                 '  buffer-size: 256;',
                 '}',
@@ -1116,10 +1103,14 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  marker-allow-overlap: true;',
                 '  marker-clip: true;',
                 '}'
-            ].join('\n');
+            ].join('\n')
+        }];
 
-            var output = this.styleTrans.transform(input, '2.3.0', '3.0.12');
-            assert.equal(output, expected);
+        realScenarios.forEach(function (scenario) {
+            it(scenario.description, function () {
+                var output = this.styleTrans.transform(scenario.input, '2.3.0', '3.0.12');
+                assert.equal(output, scenario.expected);
+            });
         });
     });
 });

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -3,7 +3,7 @@
 var assert = require('assert');
 var StyleTrans = require('../lib/grainstore/style_trans.js');
 
-describe('cartocss transformation from 2.3.x to 3.0.x', function() {
+describe.only('cartocss transformation from 2.3.x to 3.0.x', function() {
     beforeEach(function() {
         this.styleTrans = new StyleTrans();
     });

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -537,6 +537,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  marker-line-color: white;',
                 '  marker-clip: true;',
+                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -550,6 +551,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  marker-placement: interior;',
                 '  marker-clip: true;',
+                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -564,6 +566,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  marker-placement: interior;',
                 '  marker-clip: true;',
+                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -576,6 +579,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
             expected: [
                 '#layer {',
                 '  marker-clip: false;',
+                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -592,10 +596,12 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer {',
                 '  marker-line-color: white;',
                 '  marker-clip: true;',
+                '  marker-line-width: 1;',
                 '}',
                 '#layer {',
                 '  marker-placement: interior;',
                 '  marker-clip: true;',
+                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -611,6 +617,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  marker-line-color: white;',
                 '  marker-placement: interior;',
                 '  marker-clip: true;',
+                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }, {
@@ -624,6 +631,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '#layer::glow {',
                 '  marker-line-color: white;',
                 '  marker-clip: true;',
+                '  marker-line-width: 1;',
                 '}'
             ].join('\n')
         }]
@@ -1097,8 +1105,8 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  marker-placement: point;',
                 '  marker-type: ellipse;',
                 '  marker-width: [cartodb_id];',
-                '  [zoom=5]{marker-width: [cartodb_id]*2;marker-clip: true;}',
-                '  [zoom=6]{marker-width: [cartodb_id]*4;marker-clip: true;}',
+                '  [zoom=5]{marker-width: [cartodb_id]*2;marker-clip: true;marker-line-width: 1;}',
+                '  [zoom=6]{marker-width: [cartodb_id]*4;marker-clip: true;marker-line-width: 1;}',
                 '  marker-fill: #000000;',
                 '  marker-allow-overlap: true;',
                 '  marker-clip: true;',
@@ -1128,21 +1136,26 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
                 '  marker-fill: #fee5d9;',
                 '  [ scalerank = 6 ] {',
                 '    marker-fill: #fcae91;',
-                '    marker-clip: true',
+                '    marker-clip: true;',
+                '    marker-line-width: 1',
                 '  }',
                 '  [ scalerank = 8 ] {',
                 '    marker-fill: #fb6a4a;',
-                '    marker-clip: true',
+                '    marker-clip: true;',
+                '    marker-line-width: 1',
                 '  }',
                 '  [ scalerank = 4 ] {',
                 '    marker-fill: #de2d26;',
-                '    marker-clip: true',
+                '    marker-clip: true;',
+                '    marker-line-width: 1',
                 '  }',
                 '  [ scalerank = 10 ] {',
                 '    marker-fill: #a50f15;',
-                '    marker-clip: true',
+                '    marker-clip: true;',
+                '    marker-line-width: 1',
                 '  }',
-                '  marker-clip: true',
+                '  marker-clip: true;',
+                '  marker-line-width: 1',
                 '}',
             ].join('\n')
         }];

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -929,4 +929,37 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
             }.bind(this));
         });
     }.bind(this));
+
+    describe('real scenarios', function () {
+        it('should set defaults for rules that contains symbolyzers', function () {
+            var input = [
+                '#countries {',
+                '   ::outline {',
+                '       line-color: #85c5d3;',
+                '       line-width: 2;',
+                '       line-join: round;',
+                '   }',
+                '   [GEOUNIT != "United States of America"]{',
+                '       polygon-fill: #fff;',
+                '   }',
+                '}'
+            ].join('\n');
+            var expected = [
+                '#countries {',
+                '   ::outline {',
+                '       line-color: #85c5d3;',
+                '       line-width: 2;',
+                '       line-join: round;',
+                '       line-clip: true;',
+                '   }',
+                '   [GEOUNIT != "United States of America"]{',
+                '       polygon-fill: #fff;',
+                '       polygon-clip: true;',
+                '   }',
+                '}'
+            ].join('\n');
+            var outputStyle = this.styleTrans.transform(input, '2.3.0', '3.0.12');
+            assert.equal(outputStyle, expected);
+        });
+    });
 });


### PR DESCRIPTION
Fixes #118, prepare a migration path for backward incompatible changes between 2.3.x and 3.x versions. 