### PR TITLE
Restore "check" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 
 TEST_SUITE := $(shell find ./test -name "*.js")
 
-test:
+test check:
 	NODE_ENV=test ./node_modules/.bin/mocha -u tdd -t 5000 $(TEST_SUITE) ${MOCHA_ARGS}
 
-.PHONY: test
+.PHONY: test check


### PR DESCRIPTION
It was (accidentally?) removed in 67a56c0ade03e44e6ad5861ed9e75fd9b8cf46bf