### PR TITLE
Set "noop" converter when transforming from 3.0.12 to 3.0.13

### DIFF
--- a/lib/grainstore/style_trans.js
+++ b/lib/grainstore/style_trans.js
@@ -51,6 +51,12 @@ tp['2.3.0'] = {
   '3.0.12': convert_23_to_30
 };
 
+tp['3.0.12'] = {
+  '3.0.13': noop
+};
+
+
+
 StyleTrans.prototype.setLayerName = function(css, layername) {
   var ret = css.replace(/#[^\s[{;:]+\s*([:\[{])/g, '#' + layername + ' $1');
   //console.log("PRE:"); console.log(css);

--- a/test/style_trans_23_to_30.js
+++ b/test/style_trans_23_to_30.js
@@ -1276,7 +1276,7 @@ describe('cartocss transformation from 2.3.x to 3.0.x', function() {
 
         realScenarios.forEach(function (scenario) {
             it(scenario.description, function () {
-                var output = this.styleTrans.transform(scenario.input, '2.3.0', '3.0.12');
+                var output = this.styleTrans.transform(scenario.input, '2.3.0', '3.0.13');
                 assert.equal(output, scenario.expected);
             });
         });


### PR DESCRIPTION
When running with version 3.0.13 of Mapnik, the style converter breaks while trying to convert from version 3.0.12. This fix creates an "noop" convert path between these two versions.