### PR TITLE
Noop transform path from mapnik 3.0.12 to 3.0.15

### DIFF
--- a/lib/grainstore/style_trans.js
+++ b/lib/grainstore/style_trans.js
@@ -51,6 +51,10 @@ tp['2.3.0'] = {
   '3.0.12': convert_23_to_30
 };
 
+tp['3.0.12'] = {
+  '3.0.15': noop
+}
+
 StyleTrans.prototype.setLayerName = function(css, layername) {
   var ret = css.replace(/#[^\s[{;:]+\s*([:\[{])/g, '#' + layername + ' $1');
   //console.log("PRE:"); console.log(css);


### PR DESCRIPTION
Do not attempt to transform style between mapnik v3.0.12 and v3.0.15.

This fixes
https://github.com/CartoDB/Windshaft/pull/586#issuecomment-356646502

@dgaubert can you please review? we're getting closer... :smiley: 