### PR TITLE
Config markers symbolizer caches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 Version 1.8.3
 2018-XX-XX
- -
+ - Add support for `markers_symbolizer_caches` parameter to allow disabling them. See https://github.com/CartoDB/mapnik/pull/43
 
 Version 1.8.2
 2018-01-30

--- a/lib/grainstore/mml-builder/mml-builder-inline.js
+++ b/lib/grainstore/mml-builder/mml-builder-inline.js
@@ -10,9 +10,6 @@ var grainstore_defaults = {
     map: {
         srid: 3857,
         'maximum-extent': "-20037508.3,-20037508.3,20037508.3,20037508.3",
-        markers_symbolizer_caches: {
-            disabled: false
-        }
     },
     datasource: {
         type: "postgis",
@@ -249,7 +246,9 @@ MMLBuilderInline.prototype.baseMML = function() {
     mml['maximum-extent'] = this.grainstore_map['maximum-extent'];
     mml.format = this.grainstore_map.format || 'png';
     mml.Layer = [];
-    mml.markers_symbolizer_caches_disabled = this.grainstore_map.markers_symbolizer_caches.disabled;
+    if ( this.grainstore_map.markers_symbolizer_caches ) {
+        mml.markers_symbolizer_caches_disabled = this.grainstore_map.markers_symbolizer_caches.disabled.toString();
+    }
 
     for (var i=0; i<tables.length; ++i) {
         var table = tables[i];

--- a/lib/grainstore/mml-builder/mml-builder-inline.js
+++ b/lib/grainstore/mml-builder/mml-builder-inline.js
@@ -9,7 +9,10 @@ var debugXml = require('debug')('grainstore:mml-builder-inline:xml');
 var grainstore_defaults = {
     map: {
         srid: 3857,
-        'maximum-extent': "-20037508.3,-20037508.3,20037508.3,20037508.3"
+        'maximum-extent': "-20037508.3,-20037508.3,20037508.3,20037508.3",
+        markers_symbolizer_caches: {
+            disabled: false
+        }
     },
     datasource: {
         type: "postgis",

--- a/lib/grainstore/mml-builder/mml-builder-inline.js
+++ b/lib/grainstore/mml-builder/mml-builder-inline.js
@@ -35,10 +35,11 @@ var supportedDatasourceTypes = {
 
 // MML builder interface
 //
-// opts must have:
+// @param params
+// params must have:
 // `dbname`   - name of database
 //
-// opts may have:
+// params may have:
 // `sql`             - sql to constrain the map by (can be an array)
 // `ids`             - optional array<string> of layer identifiers to override the default layer id/name: `layer{index}`
 // `gcols`           - optional array of geometry column string names (defaulting to type 'geometry')
@@ -57,8 +58,8 @@ var supportedDatasourceTypes = {
 // `dbhost`          - Database host
 // `dbport`          - Database port
 //
-// @param optional_args
-//     You may pass in a third argument to override grainstore defaults.
+// @param options
+//     You may pass in a second argument to override grainstore defaults.
 //     `map` specifies the output map projection.
 //     `datasource` specifies postgis details from Mapnik postgis plugin:
 //                  https://github.com/mapnik/mapnik/wiki

--- a/lib/grainstore/mml-builder/mml-builder-inline.js
+++ b/lib/grainstore/mml-builder/mml-builder-inline.js
@@ -120,8 +120,8 @@ function MMLBuilderInline(params, options) {
     if ( options.mapnik_tile_format ) {
         this.grainstore_map.format = options.mapnik_tile_format;
     }
-    if ( params.markers_symbolizer_caches_disabled ) {
-        this.grainstore_map.markers_symbolizer_caches_disabled = params.markers_symbolizer_caches_disabled;
+    if ( params.markers_symbolizer_caches ) {
+        this.grainstore_map.markers_symbolizer_caches = params.markers_symbolizer_caches;
     }
 
     this.interactivity = params.interactivity;
@@ -246,7 +246,7 @@ MMLBuilderInline.prototype.baseMML = function() {
     mml['maximum-extent'] = this.grainstore_map['maximum-extent'];
     mml.format = this.grainstore_map.format || 'png';
     mml.Layer = [];
-    mml.markers_symbolizer_caches_disabled = this.grainstore_map.markers_symbolizer_caches_disabled;
+    mml.markers_symbolizer_caches_disabled = this.grainstore_map.markers_symbolizer_caches.disabled;
 
     for (var i=0; i<tables.length; ++i) {
         var table = tables[i];

--- a/lib/grainstore/mml-builder/mml-builder-inline.js
+++ b/lib/grainstore/mml-builder/mml-builder-inline.js
@@ -119,7 +119,7 @@ function MMLBuilderInline(params, options) {
     if ( options.mapnik_tile_format ) {
         this.grainstore_map.format = options.mapnik_tile_format;
     }
-    if ( params.markers_symbolizer_caches_disabled !== undefined ) {
+    if ( params.markers_symbolizer_caches_disabled ) {
         this.grainstore_map.markers_symbolizer_caches_disabled = params.markers_symbolizer_caches_disabled;
     }
 

--- a/lib/grainstore/mml-builder/mml-builder-inline.js
+++ b/lib/grainstore/mml-builder/mml-builder-inline.js
@@ -119,6 +119,9 @@ function MMLBuilderInline(params, options) {
     if ( options.mapnik_tile_format ) {
         this.grainstore_map.format = options.mapnik_tile_format;
     }
+    if ( params.rasterized_symbols_cache_disabled !== undefined ) {
+        this.grainstore_map.rasterized_symbols_cache_disabled = params.rasterized_symbols_cache_disabled
+    }
 
     this.interactivity = params.interactivity;
     if ( _.isString(this.interactivity) ) {
@@ -242,6 +245,8 @@ MMLBuilderInline.prototype.baseMML = function() {
     mml['maximum-extent'] = this.grainstore_map['maximum-extent'];
     mml.format = this.grainstore_map.format || 'png';
     mml.Layer = [];
+    mml.rasterized_symbols_cache_disabled = this.grainstore_map.rasterized_symbols_cache_disabled;
+    console.log('RTORRE: mml.rasterized_symbols_cache_disabled = ' + mml.rasterized_symbols_cache_disabled);
 
     for (var i=0; i<tables.length; ++i) {
         var table = tables[i];
@@ -349,7 +354,7 @@ const SUPPORTED_PROPS = {
     'group-by"': true,                 /* string */
     'buffer-size': true,               /* int */
     'maximum-extent': true,            /* string */
-    };
+};
 function getLayerProperties(params, i) {
     var properties = {};
 

--- a/lib/grainstore/mml-builder/mml-builder-inline.js
+++ b/lib/grainstore/mml-builder/mml-builder-inline.js
@@ -9,7 +9,7 @@ var debugXml = require('debug')('grainstore:mml-builder-inline:xml');
 var grainstore_defaults = {
     map: {
         srid: 3857,
-        'maximum-extent': "-20037508.3,-20037508.3,20037508.3,20037508.3",
+        'maximum-extent': "-20037508.3,-20037508.3,20037508.3,20037508.3"
     },
     datasource: {
         type: "postgis",

--- a/lib/grainstore/mml-builder/mml-builder-inline.js
+++ b/lib/grainstore/mml-builder/mml-builder-inline.js
@@ -119,8 +119,8 @@ function MMLBuilderInline(params, options) {
     if ( options.mapnik_tile_format ) {
         this.grainstore_map.format = options.mapnik_tile_format;
     }
-    if ( params.rasterized_symbols_cache_disabled !== undefined ) {
-        this.grainstore_map.rasterized_symbols_cache_disabled = params.rasterized_symbols_cache_disabled
+    if ( params.markers_symbolizer_caches_disabled !== undefined ) {
+        this.grainstore_map.markers_symbolizer_caches_disabled = params.markers_symbolizer_caches_disabled;
     }
 
     this.interactivity = params.interactivity;
@@ -245,8 +245,7 @@ MMLBuilderInline.prototype.baseMML = function() {
     mml['maximum-extent'] = this.grainstore_map['maximum-extent'];
     mml.format = this.grainstore_map.format || 'png';
     mml.Layer = [];
-    mml.rasterized_symbols_cache_disabled = this.grainstore_map.rasterized_symbols_cache_disabled;
-    console.log('RTORRE: mml.rasterized_symbols_cache_disabled = ' + mml.rasterized_symbols_cache_disabled);
+    mml.markers_symbolizer_caches_disabled = this.grainstore_map.markers_symbolizer_caches_disabled;
 
     for (var i=0; i<tables.length; ++i) {
         var table = tables[i];

--- a/test/mml_builder.js
+++ b/test/mml_builder.js
@@ -1042,7 +1042,7 @@ suite('mml_builder use_workers=' + useWorkers, function() {
             var xmlDoc = libxmljs.parseXmlString(xml);
             var xpath = "/Map/Parameters/Parameter[@name='markers_symbolizer_caches_disabled']";
             var markers_symbolizer_caches_disabled = xmlDoc.get(xpath);
-            assert.equal(markers_symbolizer_caches_disabled, undefined);
+            assert.equal(markers_symbolizer_caches_disabled.text(), "false");
         });
 
         var mml_builder = mml_store.mml_builder({

--- a/test/mml_builder.js
+++ b/test/mml_builder.js
@@ -1010,6 +1010,55 @@ suite('mml_builder use_workers=' + useWorkers, function() {
         });
     });
 
+    test('support per map markers_symbolizer_caches', function(done) {
+        var mml_store = new grainstore.MMLStore({ use_workers: useWorkers });
+
+        var mml_builder = mml_store.mml_builder({
+            dbname: 'my_database',
+            sql: SAMPLE_SQL,
+            style: DEFAULT_POINT_STYLE,
+            markers_symbolizer_caches: {
+                disabled: true
+            }
+        });
+        mml_builder.toXML((err, xml) => {
+            if (err)  { return done(err); }
+            var xmlDoc = libxmljs.parseXmlString(xml);
+            var xpath = "/Map/Parameters/Parameter[@name='markers_symbolizer_caches_disabled']";
+            var markers_symbolizer_caches_disabled = xmlDoc.get(xpath);
+            assert.equal(markers_symbolizer_caches_disabled.text(), "true");
+        });
+
+        var mml_builder = mml_store.mml_builder({
+            dbname: 'my_database',
+            sql: SAMPLE_SQL,
+            style: DEFAULT_POINT_STYLE,
+            markers_symbolizer_caches: {
+                disabled: false
+            }
+        });
+        mml_builder.toXML((err, xml) => {
+            if (err)  { return done(err); }
+            var xmlDoc = libxmljs.parseXmlString(xml);
+            var xpath = "/Map/Parameters/Parameter[@name='markers_symbolizer_caches_disabled']";
+            var markers_symbolizer_caches_disabled = xmlDoc.get(xpath);
+            assert.equal(markers_symbolizer_caches_disabled, undefined);
+        });
+
+        var mml_builder = mml_store.mml_builder({
+            dbname: 'my_database',
+            sql: SAMPLE_SQL,
+            style: DEFAULT_POINT_STYLE,
+        });
+        mml_builder.toXML((err, xml) => {
+            if (err)  { return done(err); }
+            var xmlDoc = libxmljs.parseXmlString(xml);
+            var xpath = "/Map/Parameters/Parameter[@name='markers_symbolizer_caches_disabled']";
+            var markers_symbolizer_caches_disabled = xmlDoc.get(xpath);
+            assert.equal(markers_symbolizer_caches_disabled, undefined);
+            done();
+        });
+    });
 
 });
 });


### PR DESCRIPTION
Contents of this PR:
- Add support for `markers_symbolizer_caches` parameter to allow disabling them. See https://github.com/CartoDB/mapnik/pull/43
- Tests for it
- Fix code documentation 7295d83
- Some discussion and context about the change