### PR TITLE
Prevent from uncaught exception

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+Version 1.9.1
+2018-mm-dd
+ - Prevent from uncaught exception: do not disconnect child process if it's already disconnected.
+
 Version 1.9.0
 2018-04-05
  - Add support for `markers_symbolizer_caches` parameter to allow disabling them. See https://github.com/CartoDB/mapnik/pull/43

--- a/lib/grainstore/mml-builder/mml-builder.js
+++ b/lib/grainstore/mml-builder/mml-builder.js
@@ -14,9 +14,8 @@ function createWorkersPool() {
             create: function(callback) {
                 return callback(null, fork(__dirname + '/mml-builder-child.js'));
             },
-            destroy: function(child) {
+            destroy: function (child) {
                 child.kill();
-                child.disconnect();
             },
             validate: function(child) {
                 return child && child.connected;


### PR DESCRIPTION
Do not disconnect child process if it's already disconnected. Just kill it.