### PR TITLE
Do not hang when child process is not able to generate a Mapnik XML

### DIFF
--- a/HOWTO_RELEASE
+++ b/HOWTO_RELEASE
@@ -1,9 +1,9 @@
 1. Test (make clean all check), fix if broken before proceeding
-2. Ensure proper version in package.json 
+2. Ensure proper version in package.json
 3. Ensure NEWS section exists for the new version, review it, add release date
 4. Commit package.json, NEWS
 5. git tag -a Major.Minor.Patch # use NEWS section as content
-6. Announce on cartodb@googlegroups.com
+6. npm publish
 7. Stub NEWS/package for next version
 
 Versions:
@@ -16,4 +16,3 @@ set to zero Minor and Patch.
 Branches named 'b<Major>.<Minor>' are kept for any critical
 fix that might need to be shipped before next feature release
 is ready.
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
-Version 1.10.1
+Version 1.11.0
 2018-mm-dd
+- Do not hang when child process is not able to generate a Mapnik XML
+  - Set a default timeout of 5s, configurable through `worker_timeout` param. You can disable it by setting `worker_timeout: 0`
+  - Handle ENOMEM error as special error (emits a custom event to the process)
 
 Version 1.10.0
 2018-11-20

--- a/lib/grainstore/mml-builder/mml-builder.js
+++ b/lib/grainstore/mml-builder/mml-builder.js
@@ -77,19 +77,15 @@ MMLBuilder.prototype.toXML = function(callback) {
                 return callback(new Error(result.err));
             }
 
-            if (result.err) {
-                childMMLBuilderPool.release(child);
+            childMMLBuilderPool.release(child);
 
+            if (result.err) {
                 return callback(new Error(result.err));
             }
 
             if (!result.xml) {
-                childMMLBuilderPool.release(child);
-
                 return callback(new Error('Unable to generate Mapnik XML'));
             }
-
-            childMMLBuilderPool.release(child);
 
             debug('Generated Mapnik XML');
             debugXml('output', result.xml);

--- a/lib/grainstore/mml-builder/mml-builder.js
+++ b/lib/grainstore/mml-builder/mml-builder.js
@@ -41,6 +41,8 @@ function MMLBuilder(params, options) {
     if (this.options.use_workers) {
         createWorkersPool();
     }
+
+    this.options.worker_timeout = Number.isFinite(this.options.worker_timeout) ? this.options.worker_timeout : 5000;
 }
 
 util.inherits(MMLBuilder, MMLBuilderInline);
@@ -55,28 +57,66 @@ MMLBuilder.prototype.toXML = function(callback) {
     }
 
     debug('Acquiring child process');
-    childMMLBuilderPool.acquire(function(err, child) {
+    childMMLBuilderPool.acquire(function (err, child) {
         if (err) {
             return callback(new Error('Unable to generate Mapnik XML'));
-        } else {
-            debug('Waiting for Mapnik XML');
-            child.once('message', function (result) {
-                childMMLBuilderPool.release(child);
-                debug('Genterated Mapnik XML');
-                if (result.err || !result.xml) {
-                    return callback(new Error(result.err || 'Unable to generate Mapnik XML'));
-                }
-
-                debugXml('output', result.xml);
-                return callback(null, result.xml);
-            });
-
-            debug('Sending Mapnik XML');
-
-            // Node converts a javascript object (w/ functions) to
-            // a plain object (w/o functions) before sending it to child process,
-            // thus we can use all bound context to MMLBuilder to clone it in child process
-            return child.send({ context: self });
         }
+
+        debug('Waiting for Mapnik XML');
+
+        function done (result) {
+            debug('Child process sent a result back to the parent');
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+
+            if (result.err && result.err.includes('ENOMEM')) {
+                childMMLBuilderPool.destroy(child);
+                process.emit('ENOMEM');
+
+                return callback(new Error(result.err));
+            }
+
+            if (result.err) {
+                childMMLBuilderPool.release(child);
+
+                return callback(new Error(result.err));
+            }
+
+            if (!result.xml) {
+                childMMLBuilderPool.release(child);
+
+                return callback(new Error('Unable to generate Mapnik XML'));
+            }
+
+            childMMLBuilderPool.release(child);
+
+            debug('Genterated Mapnik XML');
+            debugXml('output', result.xml);
+
+            return callback(null, result.xml);
+        }
+
+        let timeout;
+
+        if (self.options.worker_timeout > 0) {
+            timeout = setTimeout(function () {
+                child.removeListener('message', done);
+                childMMLBuilderPool.destroy(child);
+
+                debug('Timeout expired while generating Mapnik XML');
+
+                return callback(new Error('Timeout fired while generating Mapnik XML'));
+            }, self.options.worker_timeout);
+        }
+
+        child.once('message', done);
+
+        debug('Sending Mapnik XML to child process');
+
+        // Node converts a javascript object (w/ functions) to
+        // a plain object (w/o functions) before sending it to child process,
+        // thus we can use all bound context to MMLBuilder to clone it in child process
+        return child.send({ context: self });
     });
 };

--- a/lib/grainstore/mml-builder/mml-builder.js
+++ b/lib/grainstore/mml-builder/mml-builder.js
@@ -91,7 +91,7 @@ MMLBuilder.prototype.toXML = function(callback) {
 
             childMMLBuilderPool.release(child);
 
-            debug('Genterated Mapnik XML');
+            debug('Generated Mapnik XML');
             debugXml('output', result.xml);
 
             return callback(null, result.xml);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grainstore",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grainstore",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "main": "./lib/grainstore/index.js",
   "description": "Stores map styles and generates postgis friendly MML & XML for Mapnik",
   "keywords": [

--- a/test/mml_builder_pool.js
+++ b/test/mml_builder_pool.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert = require('assert');
+const grainstore = require('../lib/grainstore');
+const DEFAULT_POINT_STYLE = `
+  #layer {
+    marker-fill: #FF6600;
+    marker-opacity: 1;
+    marker-width: 16;
+    marker-line-color: white;
+    marker-line-width: 3;
+    marker-line-opacity: 0.9;
+    marker-placement: point;
+    marker-type: ellipse;
+    marker-allow-overlap: true;
+  }
+`;
+const SAMPLE_SQL = 'SELECT ST_MakePoint(0,0)';
+
+suite('mml_builder pool', function () {
+  test('should fire timeout when "worker_timeout: 1"', function (done) {
+    const mmlStore = new grainstore.MMLStore({ use_workers: true, worker_timeout: 1 });
+    mmlStore
+      .mml_builder({ dbname: 'my_database', sql: SAMPLE_SQL, style: DEFAULT_POINT_STYLE })
+      .toXML((err) => {
+        assert.equal(err.message, 'Timeout fired while generating Mapnik XML');
+        done();
+      });
+  });
+
+  test('should disable timeout when "worker_timeout: 0"', function (done) {
+    const mmlStore = new grainstore.MMLStore({ use_workers: true, worker_timeout: 0 });
+    mmlStore
+      .mml_builder({ dbname: 'my_database', sql: SAMPLE_SQL, style: DEFAULT_POINT_STYLE })
+      .toXML((err, xml) => {
+        if (err) {
+          return done(err);
+        }
+
+        assert.ok(xml.length > 0);
+        return done();
+      });
+  });
+
+  test('should NOT fire timeout when "worker_timeout: 2000"', function (done) {
+    const mmlStore = new grainstore.MMLStore({ use_workers: true, worker_timeout: 2000 });
+    mmlStore
+      .mml_builder({ dbname: 'my_database', sql: SAMPLE_SQL, style: DEFAULT_POINT_STYLE })
+      .toXML((err, xml) => {
+        if (err) {
+          return done(err);
+        }
+
+        assert.ok(xml.length > 0);
+        return done();
+      });
+  });
+
+  test('should NOT fire timeout when "worker_timeout: undefined"', function (done) {
+    const mmlStore = new grainstore.MMLStore({ use_workers: true, worker_timeout: undefined });
+    mmlStore
+      .mml_builder({ dbname: 'my_database', sql: SAMPLE_SQL, style: DEFAULT_POINT_STYLE })
+      .toXML((err, xml) => {
+        if (err) {
+          return done(err);
+        }
+
+        assert.ok(xml.length > 0);
+        return done();
+      });
+  });
+});


### PR DESCRIPTION
- Set a default timeout of 5s, configurable through `worker_timeout` param. You can disable it by setting `worker_timeout: 0`
- Handle `ENOMEM` errors as special errors (emits a custom event to the process)