### PR TITLE
Avoid uncaught exception 

### DIFF
--- a/lib/grainstore/mml-builder/mml-builder.js
+++ b/lib/grainstore/mml-builder/mml-builder.js
@@ -14,7 +14,16 @@ function createWorkersPool() {
         childMMLBuilderPool = pool.Pool({
             name: 'mml-builder',
             create: function(callback) {
-                return callback(null, fork(__dirname + '/mml-builder-child.js'));
+                try {
+                    const child = fork(__dirname + '/mml-builder-child.js');
+                    return callback(null, child);
+                } catch (err) {
+                    if (err.includes('ENOMEM')) {
+                        process.emit('ENOMEM')
+                    }
+
+                    return callback(err);
+                }
             },
             destroy: function (child) {
                 child.kill();


### PR DESCRIPTION
Avoid uncaught exception when a `ENOMEM` happens while creating a child process