### PR TITLE
Fix enomem errors

### DIFF
--- a/lib/grainstore/mml-builder/mml-builder.js
+++ b/lib/grainstore/mml-builder/mml-builder.js
@@ -9,13 +9,14 @@ var debug = require('debug')('grainstore:mml-builder');
 var debugXml = require('debug')('grainstore:mml-builder:xml');
 var childMMLBuilderPool = null;
 
-function createWorkersPool() {
+function createWorkersPool(params) {
+    var fork_function = params.fork_function || fork;
     if (!childMMLBuilderPool) {
         childMMLBuilderPool = pool.Pool({
             name: 'mml-builder',
             create: function(callback) {
                 try {
-                    const child = fork(__dirname + '/mml-builder-child.js');
+                    const child = fork_function(__dirname + '/mml-builder-child.js');
                     return callback(null, child);
                 } catch (err) {
                     if (err.includes('ENOMEM')) {
@@ -48,7 +49,7 @@ function MMLBuilder(params, options) {
     MMLBuilderInline.call(this, params, options);
 
     if (this.options.use_workers) {
-        createWorkersPool();
+        createWorkersPool(params);
     }
 
     this.options.worker_timeout = Number.isFinite(this.options.worker_timeout) ? this.options.worker_timeout : 5000;
@@ -57,6 +58,10 @@ function MMLBuilder(params, options) {
 util.inherits(MMLBuilder, MMLBuilderInline);
 
 module.exports = MMLBuilder;
+
+MMLBuilder.resetWorkersPool = function() {
+  childMMLBuilderPool = null;
+}
 
 MMLBuilder.prototype.toXML = function(callback) {
     var self = this;

--- a/lib/grainstore/mml-builder/mml-builder.js
+++ b/lib/grainstore/mml-builder/mml-builder.js
@@ -19,7 +19,7 @@ function createWorkersPool(params) {
                     const child = fork_function(__dirname + '/mml-builder-child.js');
                     return callback(null, child);
                 } catch (err) {
-                    if (err.includes('ENOMEM')) {
+                    if (err.message.includes('ENOMEM')) {
                         process.emit('ENOMEM')
                     }
 


### PR DESCRIPTION
This does two things:
- instruments the code a little and creates a test case for the faulty scenario
- adds the fix for it

They are in two separate commits. Probably the extra complexity added by the test and instrumentation is not worth the effort.

Also checked that the `result.err.includes('ENOMEM')` below shall not be changed as `result.err` is already a string and not an `Error`.